### PR TITLE
ETLegacy: adds BCs for aux variables

### DIFF
--- a/nrpy/infrastructures/ETLegacy/boundary_conditions.py
+++ b/nrpy/infrastructures/ETLegacy/boundary_conditions.py
@@ -53,6 +53,11 @@ CCTK_INT ierr CCTK_ATTRIBUTE_UNUSED = 0;
 ierr = Driver_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, -1, "{thorn_name}::{gfname}GF", "none");
 if (ierr < 0) CCTK_ERROR("Failed to register BC with Driver for {thorn_name}::{gfname}GF!");
 """
+        elif gf.group == "AUX":
+            body += f"""
+ierr = Driver_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, -1, "{thorn_name}::{gfname}GF", "flat");
+if (ierr < 0) CCTK_ERROR("Failed to register BC with Driver for {thorn_name}::{gfname}GF!");
+"""
 
     ET_schedule_bins_entries = [
         (
@@ -83,9 +88,8 @@ def register_CFunction_specify_evol_BoundaryConditions(thorn_name: str) -> None:
     Register C functions for specifying boundary conditions within a given thorn.
 
     This function generates and registers C code that sets the boundary conditions
-    for both auxiliary and evolved grid functions within a specific thorn. The
-    boundary conditions are specified based on the `Boundary` method in the
-    Einstein Toolkit.
+    for evolved grid functions within a specific thorn. The boundary conditions
+    are specified based on the `Boundary` method in the Einstein Toolkit.
 
     :param thorn_name: The name of the thorn for which to specify boundary conditions.
     :return: None
@@ -153,6 +157,76 @@ schedule GROUP ApplyBCs as {thorn_name}_ApplyBCs in MoL_PostStep after FUNC_NAME
     )
 
 
+def register_CFunction_specify_aux_BoundaryConditions(thorn_name: str) -> None:
+    """
+    Register C functions for specifying boundary conditions within a given thorn.
+
+    This function generates and registers C code that sets the boundary conditions
+    for auxiliary grid functions within a specific thorn. The
+    boundary conditions are specified based on the `Boundary` method in the
+    Einstein Toolkit.
+
+    :param thorn_name: The name of the thorn for which to specify boundary conditions.
+    :return: None
+    """
+    includes = [
+        "stdio.h",
+        "cctk.h",
+        "cctk_Arguments.h",
+        "cctk_Parameters.h",
+        "cctk_Faces.h",
+        "util_Table.h",
+    ]
+
+    desc = """
+
+This code is based on Kranc's McLachlan/ML_BSSN/src/Boundaries.cc code.
+"""
+
+    c_type = "void"
+    name = f"{thorn_name}_specify_aux_BoundaryConditions"
+    params = "CCTK_ARGUMENTS"
+
+    body = f"""  DECLARE_CCTK_ARGUMENTS_{name};
+DECLARE_CCTK_PARAMETERS;
+CCTK_INT ierr CCTK_ATTRIBUTE_UNUSED = 0;
+"""
+    for gfname, gf in sorted(gri.glb_gridfcs_dict.items()):
+        if gf.group == "AUX":
+            body += f"""
+ierr = Boundary_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, -1, "{thorn_name}::{gfname}GF", "flat");
+if (ierr < 0) CCTK_ERROR("Failed to register BC with Boundary for {thorn_name}::{gfname}GF!");
+"""
+
+    ET_schedule_bins_entries = [
+        (
+            "MoL_PseudoEvolution",
+            f"""
+schedule FUNC_NAME in MoL_PseudoEvolution
+{{
+  LANG: C
+  SYNC: aux_variables
+}} "Register boundary conditions and perform AMR+interprocessor synchronization"
+
+schedule GROUP ApplyBCs as {thorn_name}_auxgfs_ApplyBCs in MoL_PseudoEvolution after FUNC_NAME
+{{
+}} "Group for applying boundary conditions"
+""",
+        ),
+    ]
+    cfc.register_CFunction(
+        subdirectory=thorn_name,
+        includes=includes,
+        desc=desc,
+        c_type=c_type,
+        name=name,
+        params=params,
+        body=body,
+        ET_thorn_name=thorn_name,
+        ET_schedule_bins_entries=ET_schedule_bins_entries,
+    )
+
+
 def register_CFunction_specify_NewRad_BoundaryConditions_parameters(
     thorn_name: str,
 ) -> None:
@@ -201,15 +275,6 @@ schedule FUNC_NAME in MoL_CalcRHS after {thorn_name}_RHS
 }} "NewRad boundary conditions, scheduled right after RHS eval."
 """,
         ),
-        (
-            "MoL_PseudoEvolution",
-            """
-# This schedule call is not required for PreSync but remains in the schedule for backward compatibility.
-schedule GROUP ApplyBCs as WaveToy_auxgfs_ApplyBCs in MoL_PseudoEvolution after specify_BoundaryConditions
-{
-} "Apply boundary conditions"
-""",
-        ),
     ]
     cfc.register_CFunction(
         subdirectory=thorn_name,
@@ -233,6 +298,7 @@ def register_CFunctions(thorn_name: str) -> None:
     """
     register_CFunction_specify_Driver_BoundaryConditions(thorn_name=thorn_name)
     register_CFunction_specify_evol_BoundaryConditions(thorn_name=thorn_name)
+    register_CFunction_specify_aux_BoundaryConditions(thorn_name=thorn_name)
     register_CFunction_specify_NewRad_BoundaryConditions_parameters(
         thorn_name=thorn_name
     )


### PR DESCRIPTION
BCs for aux variables were missing, with partial implementation living inside the NewRad scheduling. This was split into a separate function and flat BCs were scheduled in both the pre-existing Driver function and the new Boundary function. Explicit reference to WaveToy replaced with {thorn_name}.