### PR TITLE
ETNewRad

### DIFF
--- a/nrpy/equations/general_relativity/BSSN_constraints.py
+++ b/nrpy/equations/general_relativity/BSSN_constraints.py
@@ -54,7 +54,7 @@ class BSSNconstraints:
             _ = gri.register_gridfunctions(
                 "MSQUARED", group="AUX", gf_array_name="diagnostic_output_gfs"
             )
-        if register_MU_gridfunctions and "MU" not in gri.glb_gridfcs_dict:
+        if register_MU_gridfunctions and "MU0" not in gri.glb_gridfcs_dict:
             _ = gri.register_gridfunctions_for_single_rank1(
                 "MU", group="AUX", gf_array_name="diagnostic_output_gfs"
             )

--- a/nrpy/infrastructures/ETLegacy/boundary_conditions.py
+++ b/nrpy/infrastructures/ETLegacy/boundary_conditions.py
@@ -43,19 +43,20 @@ This code is based on Kranc's McLachlan/ML_BSSN/src/Boundaries.cc code."""
     params = "CCTK_ARGUMENTS"
 
     body = f"""  DECLARE_CCTK_ARGUMENTS_{name};
-DECLARE_CCTK_PARAMETERS;
-CCTK_INT ierr CCTK_ATTRIBUTE_UNUSED = 0;
+  DECLARE_CCTK_PARAMETERS;
+  CCTK_INT ierr CCTK_ATTRIBUTE_UNUSED = 0;
+  const CCTK_INT bndsize = FD_order / 2 + 1; // <- bndsize = number of ghostzones
 """
     for gfname, gf in sorted(gri.glb_gridfcs_dict.items()):
         if gf.group == "EVOL":
             body += f"""
-ierr = Driver_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, -1, "{thorn_name}::{gfname}GF", "none");
-if (ierr < 0) CCTK_ERROR("Failed to register BC with Driver for {thorn_name}::{gfname}GF!");
+  ierr = Driver_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, -1, "{thorn_name}::{gfname}GF", "none");
+  if (ierr < 0) CCTK_ERROR("Failed to register BC with Driver for {thorn_name}::{gfname}GF!");
 """
         elif gf.group == "AUX":
             body += f"""
-ierr = Driver_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, -1, "{thorn_name}::{gfname}GF", "flat");
-if (ierr < 0) CCTK_ERROR("Failed to register BC with Driver for {thorn_name}::{gfname}GF!");
+  ierr = Driver_SelectVarForBC(cctkGH, CCTK_ALL_FACES, bndsize, -1, "{thorn_name}::{gfname}GF", "flat");
+  if (ierr < 0) CCTK_ERROR("Failed to register BC with Driver for {thorn_name}::{gfname}GF!");
 """
 
     ET_schedule_bins_entries = [
@@ -116,14 +117,14 @@ This code is based on Kranc's McLachlan/ML_BSSN/src/Boundaries.cc code."""
     params = "CCTK_ARGUMENTS"
 
     body = f"""  DECLARE_CCTK_ARGUMENTS_{name};
-DECLARE_CCTK_PARAMETERS;
-CCTK_INT ierr CCTK_ATTRIBUTE_UNUSED = 0;
+  DECLARE_CCTK_PARAMETERS;
+  CCTK_INT ierr CCTK_ATTRIBUTE_UNUSED = 0;
 """
     for gfname, gf in sorted(gri.glb_gridfcs_dict.items()):
         if gf.group == "EVOL":
             body += f"""
-ierr = Boundary_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, -1, "{thorn_name}::{gfname}GF", "none");
-if (ierr < 0) CCTK_ERROR("Failed to register BC with Boundary for {thorn_name}::{gfname}GF!");
+  ierr = Boundary_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, -1, "{thorn_name}::{gfname}GF", "none");
+  if (ierr < 0) CCTK_ERROR("Failed to register BC with Boundary for {thorn_name}::{gfname}GF!");
 """
 
     ET_schedule_bins_entries = [
@@ -185,20 +186,16 @@ This code is based on Kranc's McLachlan/ML_BSSN/src/Boundaries.cc code."""
     params = "CCTK_ARGUMENTS"
 
     body = f"""  DECLARE_CCTK_ARGUMENTS_{name};
-DECLARE_CCTK_PARAMETERS;
-CCTK_INT ierr CCTK_ATTRIBUTE_UNUSED = 0;
+  DECLARE_CCTK_PARAMETERS;
+  CCTK_INT ierr CCTK_ATTRIBUTE_UNUSED = 0;
+  const CCTK_INT bndsize = FD_order / 2 + 1; // <- bndsize = number of ghostzones
 """
     for gfname, gf in sorted(gri.glb_gridfcs_dict.items()):
         if gf.group == "AUX":
             body += f"""
-ierr = Boundary_SelectVarForBC(cctkGH, CCTK_ALL_FACES, 1, -1, "{thorn_name}::{gfname}GF", "flat");
-if (ierr < 0) CCTK_ERROR("Failed to register BC with Boundary for {thorn_name}::{gfname}GF!");
+  ierr = Boundary_SelectVarForBC(cctkGH, CCTK_ALL_FACES, bndsize, -1, "{thorn_name}::{gfname}GF", "flat");
+  if (ierr < 0) CCTK_ERROR("Failed to register BC with Boundary for {thorn_name}::{gfname}GF!");
 """
-
-    # Baikal has something like
-    #
-    # const CCTK_INT bndsize = FD_order / 2 + 1;  // <- bndsize = number of ghostzones
-    # ierr = Boundary_SelectVarForBC(cctkGH, CCTK_ALL_FACES, bndsize, -1, "Baikal::HGF", "flat");
 
     ET_schedule_bins_entries = [
         (


### PR DESCRIPTION
- Adds grid function parameter for the power for radiation boundary conditions such as NewRad in the Einstein Toolkit
- Default set to 1.0
- trK, aDD set to 2.0 in BSSN_quantities, which matches Baikal
- fixes bug in logic for registering MU grid functions, as it was checking for "MU" instead of "MU0"