### PR TITLE
Add character literals to constants

### DIFF
--- a/nrpy/c_codegen.py
+++ b/nrpy/c_codegen.py
@@ -712,6 +712,7 @@ def ccode_postproc(string: str, fp_type: str) -> str:
         "tanh",
         "exp",
         "log",
+        "log10",
         "fabs",
         "fmin",
         "fmax",

--- a/nrpy/c_codegen.py
+++ b/nrpy/c_codegen.py
@@ -253,17 +253,17 @@ def c_codegen(
     ...     print(c_codegen(1/x**2 + 1/sp.sqrt(y) - 1/sp.sin(x*z), f"{fp_type} blah", include_braces=False, verbose=False, fp_type=fp_type))
     double blah = -1/sin(x*z) + (1.0/sqrt(y)) + (1.0/((x)*(x)));
     <BLANKLINE>
-    float blah = -1/sinf(x*z) + (1.0/sqrtf(y)) + (1.0/((x)*(x)));
+    float blah = -1/sinf(x*z) + (1.0f/sqrtf(y)) + (1.0f/((x)*(x)));
     <BLANKLINE>
-    long double blah = -1/sinl(x*z) + (1.0/sqrtl(y)) + (1.0/((x)*(x)));
+    long double blah = -1/sinl(x*z) + (1.0l/sqrtl(y)) + (1.0l/((x)*(x)));
     <BLANKLINE>
     std::float16_t blah = -1/sin(x*z) + (1.0/sqrt(y)) + (1.0/((x)*(x)));
     <BLANKLINE>
-    std::float32_t blah = -1/sinf(x*z) + (1.0/sqrtf(y)) + (1.0/((x)*(x)));
+    std::float32_t blah = -1/sinf(x*z) + (1.0f/sqrtf(y)) + (1.0f/((x)*(x)));
     <BLANKLINE>
     std::float64_t blah = -1/sin(x*z) + (1.0/sqrt(y)) + (1.0/((x)*(x)));
     <BLANKLINE>
-    std::float128_t blah = -1/sinl(x*z) + (1.0/sqrtl(y)) + (1.0/((x)*(x)));
+    std::float128_t blah = -1/sinl(x*z) + (1.0l/sqrtl(y)) + (1.0l/((x)*(x)));
     <BLANKLINE>
     std::bfloat16_t blah = -1/sin(x*z) + (1.0/sqrt(y)) + (1.0/((x)*(x)));
     <BLANKLINE>

--- a/nrpy/c_codegen.py
+++ b/nrpy/c_codegen.py
@@ -429,7 +429,7 @@ def c_codegen(
                 output_varname_str[i],
                 user_functions=custom_functions_for_SymPy_ccode,
             )
-            outstring += f"{ccode_postproc(processed_code, CCGParams)}\n"
+            outstring += f"{ccode_postproc(processed_code, CCGParams.fp_type)}\n"
     # Step 4b: If CSE enabled, then perform CSE using SymPy and then
     #          resulting C code.
     else:
@@ -550,7 +550,7 @@ def c_codegen(
                             common_subexpression[0],
                             user_functions=custom_functions_for_SymPy_ccode,
                         ),
-                        CCGParams,
+                        CCGParams.fp_type,
                     )
                     + "\n"
                 )
@@ -587,7 +587,7 @@ def c_codegen(
                             varnames_excluding_SCALAR_TMPs[i],
                             user_functions=custom_functions_for_SymPy_ccode,
                         ),
-                        CCGParams,
+                        CCGParams.fp_type,
                     )
                     + "\n"
                 )
@@ -672,7 +672,7 @@ custom_functions_for_SymPy_ccode = {
 }
 
 
-def ccode_postproc(string: str, CCGParams: CCodeGen) -> str:
+def ccode_postproc(string: str, fp_type: str) -> str:
     """
     Process the generated C code string for functions related to specific data types.
 
@@ -681,7 +681,7 @@ def ccode_postproc(string: str, CCGParams: CCodeGen) -> str:
     the "L" suffix on floating point numbers when not in long double precision.
 
     :param string: The original C code string.
-    :param CCGParams: The CCodeGen object containing fp_type information.
+    :param fp_type: Floating type information.
     :return: The processed C code string.
     """
     # Append the cmath function suffix to standard C math library functions:
@@ -724,13 +724,13 @@ def ccode_postproc(string: str, CCGParams: CCodeGen) -> str:
         }
 
         # If the fp_type is not one of the known keys, raise an error
-        if CCGParams.fp_type not in cmath_suffixes:
+        if fp_type not in cmath_suffixes:
             raise ValueError(
-                f"{__name__}::fp_type = '{CCGParams.fp_type}' not supported"
+                f"{__name__}::fp_type = '{fp_type}' not supported"
             )
 
         # Get the corresponding cmath function suffix from the dictionary
-        cmath_suffix = cmath_suffixes[CCGParams.fp_type]
+        cmath_suffix = cmath_suffixes[fp_type]
 
         # Add "(" to the end of each function name and join them with '|' to create a pattern that matches any of them
         pattern = "|".join([f"{func}\\(" for func in c_funcs])
@@ -741,7 +741,7 @@ def ccode_postproc(string: str, CCGParams: CCodeGen) -> str:
         )
 
         # If fp_type is not 'long double', get rid of the "L" suffix on floating point numbers:
-        if CCGParams.fp_type != "long double":
+        if fp_type != "long double":
             string = re.sub(r"([0-9.]+)L/([0-9.]+)L", "(\\1 / \\2)", string)
 
     return string


### PR DESCRIPTION
To ensure calculations obey the desired `fp_type` (i.e. single, double, and long double precision) specified, it is worth adding the intended C type character literals to floating point numbers (e.g. `1.23 * sin(theta)`, `1.0 / 2.0 * ...`).  This could be advantageous for mixed precision codes, consistently comparing single and double precision calculations, and some of Thiago's utility codes that use quad precision could benefit from this PR with minimal refactoring to include quad precision literal types and functions.

Refactoring:
- `ccode_postproc` has been refactored to take `fp_type` as an argument rather than `CCGParams` to make it more flexible.
- ccg has been refactored to reflect this change

Extensions:
-`ccode_postproc` has been extended to include a logical branch to add character literals to constant floating point numbers (e.g. `1.0 -> 1.0f`)

Current restrictions in this PR:
- Existing character literals attached to values are not modified.  This conflicts with the current logic under the `has_c_func` branch where the `L` character literal is removed unless `long double` is specified.  In this principle this should be removed.
- Floating point values that are incomplete (e.g. `1.` vs `1.0`) will not be corrected.
- Floating point values that use scientific notation will not be modified