### PR TITLE
Simd fix

### DIFF
--- a/nrpy/examples/carpet_baikal_thorns.py
+++ b/nrpy/examples/carpet_baikal_thorns.py
@@ -247,3 +247,13 @@ EXTENDS CCTK_KEYWORD dtlapse_evolution_method "dtlapse_evolution_method"
     simd.copy_simd_intrinsics_h(
         project_dir=str(Path(project_dir) / evol_thorn_name / "src")
     )
+
+    simd_name = str(
+        Path(project_dir) / evol_thorn_name / "src" / "simd" / "simd_intrinsics.h"
+    )
+    with open(simd_name, "r") as file:
+        contents = file.read()
+    new_contents = contents.replace("REAL_SIMD_ARRAY REAL", "REAL_SIMD_ARRAY CCTK_REAL")
+
+    with open(simd_name, "w") as file:
+        file.write(new_contents)

--- a/nrpy/infrastructures/CarpetX/general_relativity/BSSN_constraints.py
+++ b/nrpy/infrastructures/CarpetX/general_relativity/BSSN_constraints.py
@@ -119,6 +119,8 @@ if(FD_order == {fd_order}) {{
             T4UU00GF, T4UU01GF, T4UU02GF, T4UU03GF"""
     schedule += f"""
     WRITES: aux_variables
+    SYNC: aux_variables
+
   }} "Compute BSSN (Hamiltonian and momentum) constraints, at finite-differencing order {fd_order}"
 }}
 """


### PR DESCRIPTION
Fixes SIMD macro for Einstein Toolkit when SIMD is deactivated.

Also includes small addition to CarpetX generation for mixed-error mode.