### PR TITLE
Update NRPyElliptic example to utilize NRPyPN for axisymmetric ID

### DIFF
--- a/nrpy/examples/nrpyelliptic_conformally_flat.py
+++ b/nrpy/examples/nrpyelliptic_conformally_flat.py
@@ -209,13 +209,13 @@ def set_single_puncture_params() -> Dict[str, Any]:
     coordinate_location = 0.0
     m_adm = 0.5
     S_z_dimless = 0.2
-    this_puncture_params = {
+    single_puncture_params = {
         "zPunc": coordinate_location,
         "bare_mass_0": compute_bare_mass(m_adm, S_z_dimless),
         "m0_adm": m_adm,
         "S0_z": S_z_dimless * m_adm**2.0,
     }
-    return this_puncture_params
+    return single_puncture_params
 # fmt: on
 
 project_dir = os.path.join("project", project_name)
@@ -360,8 +360,8 @@ if CoordSystem == "SinhSpherical":
 
 # Update parameters specific to initial data type
 if initial_data_type == "single_puncture":
-    single_puncture_params = set_single_puncture_params()
-    for param, value in single_puncture_params.items():
+    puncture_params = set_single_puncture_params()
+    for param, value in puncture_params.items():
         if param in [
             "zPunc",
             "bare_mass_0",

--- a/nrpy/examples/nrpyelliptic_conformally_flat.py
+++ b/nrpy/examples/nrpyelliptic_conformally_flat.py
@@ -139,12 +139,12 @@ def set_axisymmetric_params() -> Dict[str, Any]:
     """
     Set parameters for an axisymmetric BBH setup.
 
-    This setup by default uses the analytical estimate from 
+    This setup by default uses the analytical estimate from
     Kerr to compute bare masses unless the user specifies them
-    manually.  Thus, the solution will not produce a binary with 
-    accurate puncture masses as measured by an apparent horizon 
-    finder that match the expect puncture ADM masses.  
-    A future extension could include an iterative root finder 
+    manually.  Thus, the solution will not produce a binary with
+    accurate puncture masses as measured by an apparent horizon
+    finder that match the expect puncture ADM masses.
+    A future extension could include an iterative root finder
     to make this more robust.
 
     :return: Dictionary of parameters
@@ -197,12 +197,12 @@ def set_single_puncture_params() -> Dict[str, Any]:
     """
     Set parameters for an axisymmetric BH setup.
 
-    This setup by default uses the analytical estimate from 
+    This setup by default uses the analytical estimate from
     Kerr to compute the bare mass unless the user specifies them
-    manually.  Thus, the solution will not produce a binary with 
-    accurate puncture masses as measured by an apparent horizon 
-    finder that match the expect puncture ADM mass.  
-    A future extension could include an iterative root finder 
+    manually.  Thus, the solution will not produce a binary with
+    accurate puncture masses as measured by an apparent horizon
+    finder that match the expect puncture ADM mass.
+    A future extension could include an iterative root finder
     to make this more robust.
 
     :return: Dictionary of parameters

--- a/nrpy/examples/nrpyelliptic_conformally_flat.py
+++ b/nrpy/examples/nrpyelliptic_conformally_flat.py
@@ -13,6 +13,7 @@ import os
 import shutil
 from math import sqrt
 from typing import Any, Dict
+
 import nrpypn.eval_p_t_and_p_r as bbhp
 
 import nrpy.helpers.parallel_codegen as pcg


### PR DESCRIPTION
The primary update from this PR is to utilize NRPyPN estimates for Axisymmetric BBH ID.  As a result, the example has been restructured slightly to be cleaner and adds an analytical estimate for bare masses.  The single puncture example has been adjusted to be consistent with these changes.  

Both GW150914 and the axisymmetric case that mimics GW150914 but uses 3.5PN estimates for Pr and Pphi as well as the analytical estimate for the bare mass converge in a consistent manner.