### PR TITLE
Add optional decorators for code parameters

### DIFF
--- a/nrpy/infrastructures/BHaH/CodeParameters.py
+++ b/nrpy/infrastructures/BHaH/CodeParameters.py
@@ -143,8 +143,8 @@ def register_CFunctions_params_commondata_struct_set_to_default() -> None:
 def write_CodeParameters_h_files(
     project_dir: str,
     set_commondata_only: bool = False,
-    clang_format_options: str = "-style={BasedOnStyle: LLVM, ColumnLimit: 150}",
     decorator: str = "",
+    clang_format_options: str = "-style={BasedOnStyle: LLVM, ColumnLimit: 150}",
 ) -> None:
     r"""
     Generate C code to set C parameter constants and write them to files.

--- a/nrpy/infrastructures/BHaH/CodeParameters.py
+++ b/nrpy/infrastructures/BHaH/CodeParameters.py
@@ -144,6 +144,7 @@ def write_CodeParameters_h_files(
     project_dir: str,
     set_commondata_only: bool = False,
     clang_format_options: str = "-style={BasedOnStyle: LLVM, ColumnLimit: 150}",
+    decorator: str = "",
 ) -> None:
     r"""
     Generate C code to set C parameter constants and write them to files.
@@ -152,6 +153,7 @@ def write_CodeParameters_h_files(
     :param set_commondata_only: If True, generate code parameters only if `commondata=True`.
         Useful for BHaH projects without grids, like SEOBNR.
     :param clang_format_options: Options for clang_format.
+    :param decorator: Optional decorators for definitions to supress warnings (e.g. [[maybe_unused]])
 
     DocTests:
     >>> project_dir = Path("/tmp/tmp_project/")
@@ -189,7 +191,7 @@ def write_CodeParameters_h_files(
     # Create output directory if it doesn't already exist
     project_Path = Path(project_dir)
     project_Path.mkdir(parents=True, exist_ok=True)
-
+    decorator = decorator if decorator == "" else f"{decorator} "
     # Generate C code to set C parameter constants
     # output to filename "set_CodeParameters.h" if enable_simd==False
     # or "set_CodeParameters-simd.h" if enable_simd==True
@@ -218,7 +220,7 @@ def write_CodeParameters_h_files(
                     if "char" in CPtype and "[" in CPtype and "]" in CPtype:
                         # Handle char array C type
                         CPsize = int(CPtype.split("[")[1].split("]")[0])
-                        Coutput = rf"""char {CPname}[{CPsize}]; {comment}
+                        Coutput = rf"""{decorator}char {CPname}[{CPsize}]; {comment}
 {{
   // Copy up to {CPsize-1} characters from {struct}{pointer}{CPname} to {CPname}
   strncpy({CPname}, {struct}{pointer}{CPname}, {CPsize}-1);
@@ -238,7 +240,7 @@ def write_CodeParameters_h_files(
 }}"""
                     else:
                         # Handle all other C types
-                        Coutput = f"const {CPtype} {CPname} = {struct}{pointer}{CPname};{comment}\n"
+                        Coutput = f"{decorator}const {CPtype} {CPname} = {struct}{pointer}{CPname};{comment}\n"
 
                     returnstring += Coutput
 

--- a/nrpy/infrastructures/BHaH/CodeParameters.py
+++ b/nrpy/infrastructures/BHaH/CodeParameters.py
@@ -152,8 +152,8 @@ def write_CodeParameters_h_files(
     :param project_dir: The path of the project directory.
     :param set_commondata_only: If True, generate code parameters only if `commondata=True`.
         Useful for BHaH projects without grids, like SEOBNR.
-    :param clang_format_options: Options for clang_format.
     :param decorator: Optional decorators for definitions to supress warnings (e.g. [[maybe_unused]])
+    :param clang_format_options: Options for clang_format.
 
     DocTests:
     >>> project_dir = Path("/tmp/tmp_project/")


### PR DESCRIPTION
In many cases, especially when compiling with C++, including all CParameters, regardless of their use will result in many compiler warnings.  This change allows for optional decorators for added flexibility and correctly hint to the compiler that parameters are likely unused, when needed.