### PR TITLE
Make MAYBE_UNUSED compatible with C++ STL

### DIFF
--- a/nrpy/c_codegen.py
+++ b/nrpy/c_codegen.py
@@ -318,10 +318,10 @@ def c_codegen(
     <BLANKLINE>
     >>> print(c_codegen(x**5 + x**3 + x - 1/x, "REAL_SIMD_ARRAY blah", include_braces=False, verbose=False, enable_simd=True))
     static const double dbl_Integer_1 = 1.0;
-    const MAYBE_UNUSED REAL_SIMD_ARRAY _Integer_1 = ConstSIMD(dbl_Integer_1);
+    MAYBE_UNUSED const REAL_SIMD_ARRAY _Integer_1 = ConstSIMD(dbl_Integer_1);
     <BLANKLINE>
     static const double dbl_NegativeOne_ = -1.0;
-    const MAYBE_UNUSED REAL_SIMD_ARRAY _NegativeOne_ = ConstSIMD(dbl_NegativeOne_);
+    MAYBE_UNUSED const REAL_SIMD_ARRAY _NegativeOne_ = ConstSIMD(dbl_NegativeOne_);
     <BLANKLINE>
     REAL_SIMD_ARRAY blah = FusedMulAddSIMD(MulSIMD(x, x), x, FusedMulAddSIMD(MulSIMD(MulSIMD(MulSIMD(x, x), x), x), x, SubSIMD(x, DivSIMD(_Integer_1, x))));
     <BLANKLINE>

--- a/nrpy/c_codegen.py
+++ b/nrpy/c_codegen.py
@@ -680,8 +680,8 @@ def c_codegen(
                 # Workaround for possibly unused NegativeOne SIMD variables.
                 maybe_unused = " "
                 if varname.endswith("NegativeOne_") or varname.endswith("Integer_1"):
-                    maybe_unused = " MAYBE_UNUSED "
-                simd_RATIONAL_decls += f"const{maybe_unused}REAL_SIMD_ARRAY {varname} = ConstSIMD(dbl{varname});\n"
+                    maybe_unused = "MAYBE_UNUSED "
+                simd_RATIONAL_decls += f"{maybe_unused}const REAL_SIMD_ARRAY {varname} = ConstSIMD(dbl{varname});\n"
                 simd_RATIONAL_decls += "\n"
 
     # Step 6: Construct final output string

--- a/nrpy/helpers/simd_intrinsics.h
+++ b/nrpy/helpers/simd_intrinsics.h
@@ -1,5 +1,7 @@
 #ifndef MAYBE_UNUSED
-#if defined(__GNUC__) || defined(__clang__) || defined(__NVCC__)
+#if __cplusplus >= 201703L
+#define MAYBE_UNUSED [[maybe_unused]]
+#elif defined(__GNUC__) || defined(__clang__) || defined(__NVCC__)
 #define MAYBE_UNUSED __attribute__((unused))
 #else
 #define MAYBE_UNUSED

--- a/nrpy/infrastructures/BHaH/BHaH_defines_h.py
+++ b/nrpy/infrastructures/BHaH/BHaH_defines_h.py
@@ -197,7 +197,9 @@ def output_BHaH_defines_h(
     _a * _a; \
 }})
 #ifndef MAYBE_UNUSED
-#if defined(__GNUC__) || defined(__clang__) || defined(__NVCC__)
+#if __cplusplus >= 201703L
+#define MAYBE_UNUSED [[maybe_unused]]
+#elif defined(__GNUC__) || defined(__clang__) || defined(__NVCC__)
 #define MAYBE_UNUSED __attribute__((unused))
 #else
 #define MAYBE_UNUSED

--- a/nrpy/infrastructures/BHaH/CodeParameters.py
+++ b/nrpy/infrastructures/BHaH/CodeParameters.py
@@ -157,9 +157,9 @@ def write_CodeParameters_h_files(
     >>> project_dir = Path("/tmp/tmp_project/")
     >>> write_CodeParameters_h_files(str(project_dir))
     >>> print((project_dir / 'set_CodeParameters.h').read_text())
-    const MAYBE_UNUSED REAL a = commondata->a;                               // CodeParameters_c_files::a
-    const MAYBE_UNUSED bool BHaH_is_amazing = params->BHaH_is_amazing;       // CodeParameters_c_files::BHaH_is_amazing
-    const MAYBE_UNUSED REAL pi_three_sigfigs = commondata->pi_three_sigfigs; // CodeParameters_c_files::pi_three_sigfigs
+    MAYBE_UNUSED const REAL a = commondata->a;                               // CodeParameters_c_files::a
+    MAYBE_UNUSED const bool BHaH_is_amazing = params->BHaH_is_amazing;       // CodeParameters_c_files::BHaH_is_amazing
+    MAYBE_UNUSED const REAL pi_three_sigfigs = commondata->pi_three_sigfigs; // CodeParameters_c_files::pi_three_sigfigs
     char some_string[100];                                                   // CodeParameters_c_files::some_string
     {
       // Copy up to 99 characters from params->some_string to some_string
@@ -168,9 +168,9 @@ def write_CodeParameters_h_files(
       some_string[100 - 1] = '\0'; // Properly null terminate char array.
     }
     >>> print((project_dir / 'set_CodeParameters-nopointer.h').read_text())
-    const MAYBE_UNUSED REAL a = commondata.a;                               // CodeParameters_c_files::a
-    const MAYBE_UNUSED bool BHaH_is_amazing = params.BHaH_is_amazing;       // CodeParameters_c_files::BHaH_is_amazing
-    const MAYBE_UNUSED REAL pi_three_sigfigs = commondata.pi_three_sigfigs; // CodeParameters_c_files::pi_three_sigfigs
+    MAYBE_UNUSED const REAL a = commondata.a;                               // CodeParameters_c_files::a
+    MAYBE_UNUSED const bool BHaH_is_amazing = params.BHaH_is_amazing;       // CodeParameters_c_files::BHaH_is_amazing
+    MAYBE_UNUSED const REAL pi_three_sigfigs = commondata.pi_three_sigfigs; // CodeParameters_c_files::pi_three_sigfigs
     char some_string[100];                                                  // CodeParameters_c_files::some_string
     {
       // Copy up to 99 characters from params.some_string to some_string
@@ -180,10 +180,10 @@ def write_CodeParameters_h_files(
     }
     >>> print((project_dir / 'set_CodeParameters-simd.h').read_text())
     const REAL NOSIMDa = commondata->a;                                                      // CodeParameters_c_files::a
-    const MAYBE_UNUSED REAL_SIMD_ARRAY a = ConstSIMD(NOSIMDa);                               // CodeParameters_c_files::a
-    const MAYBE_UNUSED bool BHaH_is_amazing = params->BHaH_is_amazing;                       // CodeParameters_c_files::BHaH_is_amazing
+    MAYBE_UNUSED const REAL_SIMD_ARRAY a = ConstSIMD(NOSIMDa);                               // CodeParameters_c_files::a
+    MAYBE_UNUSED const bool BHaH_is_amazing = params->BHaH_is_amazing;                       // CodeParameters_c_files::BHaH_is_amazing
     const REAL NOSIMDpi_three_sigfigs = commondata->pi_three_sigfigs;                        // CodeParameters_c_files::pi_three_sigfigs
-    const MAYBE_UNUSED REAL_SIMD_ARRAY pi_three_sigfigs = ConstSIMD(NOSIMDpi_three_sigfigs); // CodeParameters_c_files::pi_three_sigfigs
+    MAYBE_UNUSED const REAL_SIMD_ARRAY pi_three_sigfigs = ConstSIMD(NOSIMDpi_three_sigfigs); // CodeParameters_c_files::pi_three_sigfigs
     <BLANKLINE>
     """
     # Create output directory if it doesn't already exist
@@ -239,7 +239,7 @@ def write_CodeParameters_h_files(
                     else:
                         # Handle all other C types.
                         # MAYBE_UNUSED is used to avoid compiler warnings about unused variables from including set_CodeParameters_simd.h.
-                        Coutput = f"const MAYBE_UNUSED {CPtype} {CPname} = {struct}{pointer}{CPname};{comment}\n"
+                        Coutput = f"MAYBE_UNUSED const {CPtype} {CPname} = {struct}{pointer}{CPname};{comment}\n"
 
                     returnstring += Coutput
 
@@ -283,11 +283,11 @@ def write_CodeParameters_h_files(
                     c_output = (
                         f"const REAL NOSIMD{CPname} = {struct}->{CPname};{comment}\n"
                     )
-                    c_output += f"const MAYBE_UNUSED REAL_SIMD_ARRAY {CPname} = ConstSIMD(NOSIMD{CPname});{comment}\n"
+                    c_output += f"MAYBE_UNUSED const REAL_SIMD_ARRAY {CPname} = ConstSIMD(NOSIMD{CPname});{comment}\n"
                     set_CodeParameters_SIMD_str += c_output
                 else:
                     # MAYBE_UNUSED is used to avoid compiler warnings about unused variables from including set_CodeParameters_simd.h.
-                    c_output = f"const MAYBE_UNUSED {CPtype} {CPname} = {struct}->{CPname};{comment}\n"
+                    c_output = f"MAYBE_UNUSED const {CPtype} {CPname} = {struct}->{CPname};{comment}\n"
                     set_CodeParameters_SIMD_str += c_output
 
     header_file_simd_path = project_Path / "set_CodeParameters-simd.h"

--- a/nrpy/infrastructures/BHaH/checkpointing.py
+++ b/nrpy/infrastructures/BHaH/checkpointing.py
@@ -28,7 +28,7 @@ def register_CFunction_read_checkpoint(
     """
     includes = ["BHaH_defines.h", "BHaH_function_prototypes.h", "unistd.h"]
     prefunc = r"""
-#define FREAD(ptr, size, nmemb, stream) { const MAYBE_UNUSED int numitems=fread((ptr), (size), (nmemb), (stream)); }
+#define FREAD(ptr, size, nmemb, stream) { MAYBE_UNUSED const int numitems=fread((ptr), (size), (nmemb), (stream)); }
 """
     desc = "Read a checkpoint file"
     cfunc_type = "int"

--- a/nrpy/infrastructures/BHaH/diagnostics/output_0d_1d_2d_nearest_gridpoint_slices.py
+++ b/nrpy/infrastructures/BHaH/diagnostics/output_0d_1d_2d_nearest_gridpoint_slices.py
@@ -111,7 +111,7 @@ In SinhSymTP, this will be at i0_min,i1_mid,i2_mid (i2 == phi doesn't matter).""
     body = rf"""
 // Unpack grid function pointers from gridfuncs struct
 const REAL *restrict y_n_gfs = gridfuncs->y_n_gfs;
-const MAYBE_UNUSED REAL *restrict auxevol_gfs = gridfuncs->auxevol_gfs;
+MAYBE_UNUSED const REAL *restrict auxevol_gfs = gridfuncs->auxevol_gfs;
 const REAL *restrict diagnostic_output_gfs = gridfuncs->diagnostic_output_gfs;
 
 // Output to file diagnostic quantities at grid's *physical* center.
@@ -198,7 +198,7 @@ def register_CFunction_diagnostics_nearest_1d_axis(
     body = rf"""
 // Unpack grid function pointers from gridfuncs struct
 const REAL *restrict y_n_gfs = gridfuncs->y_n_gfs;
-const MAYBE_UNUSED REAL *restrict auxevol_gfs = gridfuncs->auxevol_gfs;
+MAYBE_UNUSED const REAL *restrict auxevol_gfs = gridfuncs->auxevol_gfs;
 const REAL *restrict diagnostic_output_gfs = gridfuncs->diagnostic_output_gfs;
 
 // Prepare output filename based on 1D axis
@@ -279,7 +279,7 @@ def register_CFunction_diagnostics_nearest_2d_plane(
     body = rf"""
 // Unpack grid function pointers from gridfuncs struct
 const REAL *restrict y_n_gfs = gridfuncs->y_n_gfs;
-const MAYBE_UNUSED REAL *restrict auxevol_gfs = gridfuncs->auxevol_gfs;
+MAYBE_UNUSED const REAL *restrict auxevol_gfs = gridfuncs->auxevol_gfs;
 const REAL *restrict diagnostic_output_gfs = gridfuncs->diagnostic_output_gfs;
 
 // Prepare output filename based on 2D plane

--- a/nrpy/infrastructures/BHaH/diagnostics/tests/output_0d_1d_2d_nearest_gridpoint_slices_SinhSpherical_y_axis.c
+++ b/nrpy/infrastructures/BHaH/diagnostics/tests/output_0d_1d_2d_nearest_gridpoint_slices_SinhSpherical_y_axis.c
@@ -22,7 +22,7 @@ void diagnostics_nearest_1d_y_axis__rfm__SinhSpherical(commondata_struct *restri
 
   // Unpack grid function pointers from gridfuncs struct
   const REAL *restrict y_n_gfs = gridfuncs->y_n_gfs;
-  const MAYBE_UNUSED REAL *restrict auxevol_gfs = gridfuncs->auxevol_gfs;
+  MAYBE_UNUSED const REAL *restrict auxevol_gfs = gridfuncs->auxevol_gfs;
   const REAL *restrict diagnostic_output_gfs = gridfuncs->diagnostic_output_gfs;
 
   // Prepare output filename based on 1D axis

--- a/nrpy/infrastructures/BHaH/diagnostics/tests/output_0d_1d_2d_nearest_gridpoint_slices_SinhSymTP_yz_plane.c
+++ b/nrpy/infrastructures/BHaH/diagnostics/tests/output_0d_1d_2d_nearest_gridpoint_slices_SinhSymTP_yz_plane.c
@@ -9,7 +9,7 @@ void diagnostics_nearest_2d_yz_plane__rfm__SinhSymTP(commondata_struct *restrict
 
   // Unpack grid function pointers from gridfuncs struct
   const REAL *restrict y_n_gfs = gridfuncs->y_n_gfs;
-  const MAYBE_UNUSED REAL *restrict auxevol_gfs = gridfuncs->auxevol_gfs;
+  MAYBE_UNUSED const REAL *restrict auxevol_gfs = gridfuncs->auxevol_gfs;
   const REAL *restrict diagnostic_output_gfs = gridfuncs->diagnostic_output_gfs;
 
   // Prepare output filename based on 2D plane

--- a/nrpy/infrastructures/BHaH/diagnostics/tests/output_0d_1d_2d_nearest_gridpoint_slices_grid_center.c
+++ b/nrpy/infrastructures/BHaH/diagnostics/tests/output_0d_1d_2d_nearest_gridpoint_slices_grid_center.c
@@ -14,7 +14,7 @@ void diagnostics_nearest_grid_center__rfm__SinhCylindrical(commondata_struct *re
 
   // Unpack grid function pointers from gridfuncs struct
   const REAL *restrict y_n_gfs = gridfuncs->y_n_gfs;
-  const MAYBE_UNUSED REAL *restrict auxevol_gfs = gridfuncs->auxevol_gfs;
+  MAYBE_UNUSED const REAL *restrict auxevol_gfs = gridfuncs->auxevol_gfs;
   const REAL *restrict diagnostic_output_gfs = gridfuncs->diagnostic_output_gfs;
 
   // Output to file diagnostic quantities at grid's *physical* center.

--- a/nrpy/infrastructures/BHaH/numerical_grids_and_timestep.py
+++ b/nrpy/infrastructures/BHaH/numerical_grids_and_timestep.py
@@ -187,9 +187,9 @@ REAL ds_min = 1e38;
 LOOP_NOOMP(i0, 0, Nxx_plus_2NGHOSTS0,
            i1, 0, Nxx_plus_2NGHOSTS1,
            i2, 0, Nxx_plus_2NGHOSTS2) {
-    const MAYBE_UNUSED REAL xx0 = xx[0][i0];
-    const MAYBE_UNUSED REAL xx1 = xx[1][i1];
-    const MAYBE_UNUSED REAL xx2 = xx[2][i2];
+    MAYBE_UNUSED const REAL xx0 = xx[0][i0];
+    MAYBE_UNUSED const REAL xx1 = xx[1][i1];
+    MAYBE_UNUSED const REAL xx2 = xx[2][i2];
     REAL dsmin0, dsmin1, dsmin2;
 """
     rfm = refmetric.reference_metric[CoordSystem]

--- a/nrpy/infrastructures/BHaH/rfm_precompute.py
+++ b/nrpy/infrastructures/BHaH/rfm_precompute.py
@@ -103,16 +103,16 @@ class ReferenceMetricPrecompute:
                         self.rfm_struct__define += "}\n\n"
                         self.readvr_str[
                             dirn
-                        ] += f"const MAYBE_UNUSED REAL {freevars_uniq_xx_indep[which_freevar]} = rfmstruct->{freevars_uniq_xx_indep[which_freevar]}[i{dirn}];\n"
+                        ] += f"MAYBE_UNUSED const REAL {freevars_uniq_xx_indep[which_freevar]} = rfmstruct->{freevars_uniq_xx_indep[which_freevar]}[i{dirn}];\n"
                         self.readvr_SIMD_outer_str[
                             dirn
                         ] += f"const double NOSIMD{freevars_uniq_xx_indep[which_freevar]} = rfmstruct->{freevars_uniq_xx_indep[which_freevar]}[i{dirn}]; "
                         self.readvr_SIMD_outer_str[
                             dirn
-                        ] += f"const MAYBE_UNUSED REAL_SIMD_ARRAY {freevars_uniq_xx_indep[which_freevar]} = ConstSIMD(NOSIMD{freevars_uniq_xx_indep[which_freevar]});\n"
+                        ] += f"MAYBE_UNUSED const REAL_SIMD_ARRAY {freevars_uniq_xx_indep[which_freevar]} = ConstSIMD(NOSIMD{freevars_uniq_xx_indep[which_freevar]});\n"
                         self.readvr_SIMD_inner_str[
                             dirn
-                        ] += f"const MAYBE_UNUSED REAL_SIMD_ARRAY {freevars_uniq_xx_indep[which_freevar]} = ReadSIMD(&rfmstruct->{freevars_uniq_xx_indep[which_freevar]}[i{dirn}]);\n"
+                        ] += f"MAYBE_UNUSED const REAL_SIMD_ARRAY {freevars_uniq_xx_indep[which_freevar]} = ReadSIMD(&rfmstruct->{freevars_uniq_xx_indep[which_freevar]}[i{dirn}]);\n"
                         output_define_and_readvr = True
 
                 if (
@@ -128,16 +128,16 @@ class ReferenceMetricPrecompute:
                 }}\n\n"""
                     self.readvr_str[
                         0
-                    ] += f"const MAYBE_UNUSED REAL {freevars_uniq_xx_indep[which_freevar]} = rfmstruct->{freevars_uniq_xx_indep[which_freevar]}[i0 + Nxx_plus_2NGHOSTS0*i1];\n"
+                    ] += f"MAYBE_UNUSED const REAL {freevars_uniq_xx_indep[which_freevar]} = rfmstruct->{freevars_uniq_xx_indep[which_freevar]}[i0 + Nxx_plus_2NGHOSTS0*i1];\n"
                     self.readvr_SIMD_outer_str[
                         0
                     ] += f"const double NOSIMD{freevars_uniq_xx_indep[which_freevar]} = rfmstruct->{freevars_uniq_xx_indep[which_freevar]}[i0 + Nxx_plus_2NGHOSTS0*i1]; "
                     self.readvr_SIMD_outer_str[
                         0
-                    ] += f"const MAYBE_UNUSED REAL_SIMD_ARRAY {freevars_uniq_xx_indep[which_freevar]} = ConstSIMD(NOSIMD{freevars_uniq_xx_indep[which_freevar]});\n"
+                    ] += f"MAYBE_UNUSED const REAL_SIMD_ARRAY {freevars_uniq_xx_indep[which_freevar]} = ConstSIMD(NOSIMD{freevars_uniq_xx_indep[which_freevar]});\n"
                     self.readvr_SIMD_inner_str[
                         0
-                    ] += f"const MAYBE_UNUSED REAL_SIMD_ARRAY {freevars_uniq_xx_indep[which_freevar]} = ReadSIMD(&rfmstruct->{freevars_uniq_xx_indep[which_freevar]}[i0 + Nxx_plus_2NGHOSTS0*i1]);\n"
+                    ] += f"MAYBE_UNUSED const REAL_SIMD_ARRAY {freevars_uniq_xx_indep[which_freevar]} = ReadSIMD(&rfmstruct->{freevars_uniq_xx_indep[which_freevar]}[i0 + Nxx_plus_2NGHOSTS0*i1]);\n"
                     output_define_and_readvr = True
 
                 if not output_define_and_readvr:

--- a/nrpy/infrastructures/BHaH/simple_loop.py
+++ b/nrpy/infrastructures/BHaH/simple_loop.py
@@ -70,19 +70,19 @@ def simple_loop(
     for (int i2 = NGHOSTS; i2 < NGHOSTS + Nxx2; i2++) {
       for (int i1 = NGHOSTS; i1 < NGHOSTS + Nxx1; i1++) {
         for (int i0 = NGHOSTS; i0 < NGHOSTS + Nxx0; i0++) {
-          const MAYBE_UNUSED REAL f1_of_xx1 = rfmstruct->f1_of_xx1[i1];
-          const MAYBE_UNUSED REAL f1_of_xx1__D1 = rfmstruct->f1_of_xx1__D1[i1];
-          const MAYBE_UNUSED REAL f1_of_xx1__DD11 = rfmstruct->f1_of_xx1__DD11[i1];
-          const MAYBE_UNUSED REAL f4_of_xx1 = rfmstruct->f4_of_xx1[i1];
-          const MAYBE_UNUSED REAL f4_of_xx1__D1 = rfmstruct->f4_of_xx1__D1[i1];
-          const MAYBE_UNUSED REAL f4_of_xx1__DD11 = rfmstruct->f4_of_xx1__DD11[i1];
-          const MAYBE_UNUSED REAL f0_of_xx0 = rfmstruct->f0_of_xx0[i0];
-          const MAYBE_UNUSED REAL f0_of_xx0__D0 = rfmstruct->f0_of_xx0__D0[i0];
-          const MAYBE_UNUSED REAL f0_of_xx0__DD00 = rfmstruct->f0_of_xx0__DD00[i0];
-          const MAYBE_UNUSED REAL f0_of_xx0__DDD000 = rfmstruct->f0_of_xx0__DDD000[i0];
-          const MAYBE_UNUSED REAL f2_of_xx0 = rfmstruct->f2_of_xx0[i0];
-          const MAYBE_UNUSED REAL f2_of_xx0__D0 = rfmstruct->f2_of_xx0__D0[i0];
-          const MAYBE_UNUSED REAL f2_of_xx0__DD00 = rfmstruct->f2_of_xx0__DD00[i0];
+          MAYBE_UNUSED const REAL f1_of_xx1 = rfmstruct->f1_of_xx1[i1];
+          MAYBE_UNUSED const REAL f1_of_xx1__D1 = rfmstruct->f1_of_xx1__D1[i1];
+          MAYBE_UNUSED const REAL f1_of_xx1__DD11 = rfmstruct->f1_of_xx1__DD11[i1];
+          MAYBE_UNUSED const REAL f4_of_xx1 = rfmstruct->f4_of_xx1[i1];
+          MAYBE_UNUSED const REAL f4_of_xx1__D1 = rfmstruct->f4_of_xx1__D1[i1];
+          MAYBE_UNUSED const REAL f4_of_xx1__DD11 = rfmstruct->f4_of_xx1__DD11[i1];
+          MAYBE_UNUSED const REAL f0_of_xx0 = rfmstruct->f0_of_xx0[i0];
+          MAYBE_UNUSED const REAL f0_of_xx0__D0 = rfmstruct->f0_of_xx0__D0[i0];
+          MAYBE_UNUSED const REAL f0_of_xx0__DD00 = rfmstruct->f0_of_xx0__DD00[i0];
+          MAYBE_UNUSED const REAL f0_of_xx0__DDD000 = rfmstruct->f0_of_xx0__DDD000[i0];
+          MAYBE_UNUSED const REAL f2_of_xx0 = rfmstruct->f2_of_xx0[i0];
+          MAYBE_UNUSED const REAL f2_of_xx0__D0 = rfmstruct->f2_of_xx0__D0[i0];
+          MAYBE_UNUSED const REAL f2_of_xx0__DD00 = rfmstruct->f2_of_xx0__DD00[i0];
           // <INTERIOR>
         } // END LOOP: for (int i0 = NGHOSTS; i0 < NGHOSTS+Nxx0; i0++)
       } // END LOOP: for (int i1 = NGHOSTS; i1 < NGHOSTS+Nxx1; i1++)
@@ -93,21 +93,21 @@ def simple_loop(
     #pragma omp parallel for collapse(2)
     for (int i2 = NGHOSTS; i2 < NGHOSTS + Nxx2; i2++) {
       for (int i1 = NGHOSTS; i1 < NGHOSTS + Nxx1; i1++) {
-        const MAYBE_UNUSED REAL f1_of_xx1 = rfmstruct->f1_of_xx1[i1];
-        const MAYBE_UNUSED REAL f1_of_xx1__D1 = rfmstruct->f1_of_xx1__D1[i1];
-        const MAYBE_UNUSED REAL f1_of_xx1__DD11 = rfmstruct->f1_of_xx1__DD11[i1];
-        const MAYBE_UNUSED REAL f4_of_xx1 = rfmstruct->f4_of_xx1[i1];
-        const MAYBE_UNUSED REAL f4_of_xx1__D1 = rfmstruct->f4_of_xx1__D1[i1];
-        const MAYBE_UNUSED REAL f4_of_xx1__DD11 = rfmstruct->f4_of_xx1__DD11[i1];
+        MAYBE_UNUSED const REAL f1_of_xx1 = rfmstruct->f1_of_xx1[i1];
+        MAYBE_UNUSED const REAL f1_of_xx1__D1 = rfmstruct->f1_of_xx1__D1[i1];
+        MAYBE_UNUSED const REAL f1_of_xx1__DD11 = rfmstruct->f1_of_xx1__DD11[i1];
+        MAYBE_UNUSED const REAL f4_of_xx1 = rfmstruct->f4_of_xx1[i1];
+        MAYBE_UNUSED const REAL f4_of_xx1__D1 = rfmstruct->f4_of_xx1__D1[i1];
+        MAYBE_UNUSED const REAL f4_of_xx1__DD11 = rfmstruct->f4_of_xx1__DD11[i1];
     <BLANKLINE>
         for (int i0 = NGHOSTS; i0 < NGHOSTS + Nxx0; i0++) {
-          const MAYBE_UNUSED REAL f0_of_xx0 = rfmstruct->f0_of_xx0[i0];
-          const MAYBE_UNUSED REAL f0_of_xx0__D0 = rfmstruct->f0_of_xx0__D0[i0];
-          const MAYBE_UNUSED REAL f0_of_xx0__DD00 = rfmstruct->f0_of_xx0__DD00[i0];
-          const MAYBE_UNUSED REAL f0_of_xx0__DDD000 = rfmstruct->f0_of_xx0__DDD000[i0];
-          const MAYBE_UNUSED REAL f2_of_xx0 = rfmstruct->f2_of_xx0[i0];
-          const MAYBE_UNUSED REAL f2_of_xx0__D0 = rfmstruct->f2_of_xx0__D0[i0];
-          const MAYBE_UNUSED REAL f2_of_xx0__DD00 = rfmstruct->f2_of_xx0__DD00[i0];
+          MAYBE_UNUSED const REAL f0_of_xx0 = rfmstruct->f0_of_xx0[i0];
+          MAYBE_UNUSED const REAL f0_of_xx0__D0 = rfmstruct->f0_of_xx0__D0[i0];
+          MAYBE_UNUSED const REAL f0_of_xx0__DD00 = rfmstruct->f0_of_xx0__DD00[i0];
+          MAYBE_UNUSED const REAL f0_of_xx0__DDD000 = rfmstruct->f0_of_xx0__DDD000[i0];
+          MAYBE_UNUSED const REAL f2_of_xx0 = rfmstruct->f2_of_xx0[i0];
+          MAYBE_UNUSED const REAL f2_of_xx0__D0 = rfmstruct->f2_of_xx0__D0[i0];
+          MAYBE_UNUSED const REAL f2_of_xx0__DD00 = rfmstruct->f2_of_xx0__DD00[i0];
           // <INTERIOR>
         } // END LOOP: for (int i0 = NGHOSTS; i0 < NGHOSTS+Nxx0; i0++)
       } // END LOOP: for (int i1 = NGHOSTS; i1 < NGHOSTS+Nxx1; i1++)
@@ -138,9 +138,9 @@ def simple_loop(
     if read_xxs:
         if not enable_simd:
             read_rfm_xx_arrays = [
-                "const MAYBE_UNUSED REAL xx0 = xx[0][i0];",
-                "const MAYBE_UNUSED REAL xx1 = xx[1][i1];",
-                "const MAYBE_UNUSED REAL xx2 = xx[2][i2];",
+                "MAYBE_UNUSED const REAL xx0 = xx[0][i0];",
+                "MAYBE_UNUSED const REAL xx1 = xx[1][i1];",
+                "MAYBE_UNUSED const REAL xx2 = xx[2][i2];",
             ]
         else:
             raise ValueError("no innerSIMD support for Read_xxs (currently).")

--- a/nrpy/infrastructures/BHaH/tests/BHaH_defines_h_BHaH_defines.c
+++ b/nrpy/infrastructures/BHaH/tests/BHaH_defines_h_BHaH_defines.c
@@ -44,7 +44,9 @@
     _a *_a;                                                                                                                                          \
   })
 #ifndef MAYBE_UNUSED
-#if defined(__GNUC__) || defined(__clang__) || defined(__NVCC__)
+#if __cplusplus >= 201703L
+#define MAYBE_UNUSED [[maybe_unused]]
+#elif defined(__GNUC__) || defined(__clang__) || defined(__NVCC__)
 #define MAYBE_UNUSED __attribute__((unused))
 #else
 #define MAYBE_UNUSED

--- a/nrpy/infrastructures/BHaH/wave_equation/wave_equation_C_codegen_library.py
+++ b/nrpy/infrastructures/BHaH/wave_equation/wave_equation_C_codegen_library.py
@@ -250,7 +250,7 @@ def register_CFunction_diagnostics(
   if (fabs(round(currtime / outevery) * outevery - currtime) < 0.5 * currdt) {
     for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
       // Unpack griddata struct:
-      const MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+      MAYBE_UNUSED const REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
       REAL *restrict diagnostic_output_gfs = griddata[grid].gridfuncs.diagnostic_output_gfs;
       REAL *restrict xx[3];
       for (int ww = 0; ww < 3; ww++)


### PR DESCRIPTION
In this PR, the recently added `MAYBE_UNUSED` macro in NRPy has been updated to be compatible with the C++ standard library decorator `[[maybe_unused]]`, which provides a consist implementation independent of the compiler so long as the executable is compiled using the C++17 or later standard.

C++, however, has a strict ordering for decorators.  As a consequence, the order for using `MAYBE_UNUSED` had to be changed throughout NRPy from the original `const MAYBE_UNUSED` to `MAYBE_UNUSED const`.