### PR TITLE
MoL added flexibility to support CUDA

### DIFF
--- a/nrpy/examples/nrpyelliptic_conformally_flat.py
+++ b/nrpy/examples/nrpyelliptic_conformally_flat.py
@@ -235,6 +235,9 @@ cbc.CurviBoundaryConditions_register_C_functions(
 )
 rhs_string = """rhs_eval(commondata, params, rfmstruct,  auxevol_gfs, RK_INPUT_GFS, RK_OUTPUT_GFS);
 if (strncmp(commondata->outer_bc_type, "radiation", 50) == 0){
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
   const REAL wavespeed_at_outer_boundary = auxevol_gfs[IDX4(VARIABLE_WAVESPEEDGF, Nxx_plus_2NGHOSTS0-NGHOSTS-1, NGHOSTS, Nxx_plus_2NGHOSTS2/2)];
   const REAL custom_gridfunctions_wavespeed[2] = {wavespeed_at_outer_boundary, wavespeed_at_outer_boundary};
   apply_bcs_outerradiation_and_inner(commondata, params, bcstruct, griddata->xx,

--- a/nrpy/helpers/generic.py
+++ b/nrpy/helpers/generic.py
@@ -116,6 +116,7 @@ def validate_strings(
 
     :param to_check: Specify the string to validate, representing the expected value or output.
     :param string_desc: Provide a short, non-empty, whitespace-free label to use in the trusted file's name.
+    :param file_ext: Specify the file extension for the trusted file, defaulting to "c".
     :raises ValueError: Raise if:
         - `string_desc` is empty or contains whitespace.
         - The caller's frame or filename cannot be identified.

--- a/nrpy/helpers/generic.py
+++ b/nrpy/helpers/generic.py
@@ -105,6 +105,7 @@ def clang_format(
 def validate_strings(
     to_check: str,
     string_desc: str,
+    file_ext: str = "c",
 ) -> None:
     """
     Validate a string against a trusted value stored in a .c file; manage trusted file creation if file not found.
@@ -165,7 +166,7 @@ def validate_strings(
         # Use the script's filename if function name is not meaningful
         function_name = Path(caller_filename).stem
 
-    outfile_path = outdir / f"{function_name}_{string_desc}.c"
+    outfile_path = outdir / f"{function_name}_{string_desc}.{file_ext}"
 
     if outfile_path.exists():
         trusted_string = outfile_path.read_text(encoding="utf-8")

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/MoL.py
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/MoL.py
@@ -1030,7 +1030,6 @@ def register_CFunction_MoL_free_memory(
     desc += "   - y_n_gfs are used to store data for the vector of gridfunctions y_i at t_n, at the start of each MoL timestep\n"
     desc += "   - non_y_n_gfs are needed for intermediate (e.g., k_i) storage in chosen MoL method\n"
     cfunc_type = "void"
-    mem_free_func = "free" if parallelization != "cuda" else "cudaFree"
 
     (
         y_n_gridfunctions,
@@ -1053,10 +1052,9 @@ def register_CFunction_MoL_free_memory(
         # Don't free a zero-sized array.
         if gridfunction == "auxevol_gfs":
             body += (
-                f"  if(NUM_AUXEVOL_GFS > 0) {mem_free_func}(gridfuncs->{gridfunction});"
+                f"  if(NUM_AUXEVOL_GFS > 0)"
             )
-        else:
-            body += f"  {mem_free_func}(gridfuncs->{gridfunction});"
+        body += f" {'cudaFree' if parallelization == 'cuda' else 'free'}(gridfuncs->{gridfunction});\n"
     cfc.register_CFunction(
         includes=includes,
         desc=desc,

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/MoL.py
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/MoL.py
@@ -1126,7 +1126,7 @@ REAL *restrict diagnostic_output_gfs2;
 
 #define LOOP_ALL_GFS_GPS(ii) \
 _Pragma("omp parallel for") \
-  for(int (ii)=0;(ii)<Nxx_plus_2NGHOSTS0*Nxx_plus_2NGHOSTS1*Nxx_plus_2NGHOSTS2*NUM_EVOL_GFS;(ii)++)
+  for(int (ii)=0;(ii)<Ntot;(ii)++)
 """,
     )
 

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/MoL.py
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/MoL.py
@@ -654,7 +654,7 @@ def register_CFunction_MoL_step_forward_in_time(
     ...     )
     ...     generated_str = cfc.CFunction_dict["MoL_step_forward_in_time"].full_function
     ...     validation_desc = f"CUDA__MoL_step_forward_in_time__{k}".replace(" ", "_")
-    ...     validate_strings(generated_str, validation_desc)
+    ...     validate_strings(generated_str, validation_desc, file_ext="cu")
     >>> cfc.CFunction_dict.clear()
     >>> MoL_Functions_dict.clear()
     >>> try:

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/MoL.py
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/MoL.py
@@ -167,7 +167,7 @@ class RKFunction:
                 if self.enable_intrinsics and parallelization == "openmp":
                     self.kernel_params[key] = "REAL *restrict"
                     self.params += f"{var_type} *restrict {key},"
-                    kernel_body += f"const {var_type} {el} = Read{self.intrinsics_str}(&{gfs_el});\n"
+                    kernel_body += f"const REAL_SIMD_ARRAY {el} = Read{self.intrinsics_str}(&{gfs_el});\n"
                 else:
                     self.kernel_params[key] = "REAL *restrict"
                     self.params += f"{var_type} *restrict {key},"
@@ -203,6 +203,9 @@ class RKFunction:
             self.body += device_kernel.c_function_call()
             prefunc = device_kernel.CFunction.full_function
         else:
+            if self.enable_intrinsics:
+                kernel_body = kernel_body.replace("dt", "DT")
+                kernel_body = "const REAL_SIMD_ARRAY DT = ConstSIMD(dt);\n" + kernel_body
             rk_substep_prefunc = cfc.CFunction(
                 desc=self.desc,
                 cfunc_type=self.cfunc_type,

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__CK5.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__CK5.cu
@@ -1,0 +1,489 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_5 = 1.0 / 5.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_5 = ConstCUDA(dblRK_Rational_1_5);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_1_5, MulCUDA(k1_gfsL, dt), y_n_gfsL);
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_3_40 = 3.0 / 40.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_40 = ConstCUDA(dblRK_Rational_3_40);
+
+    static const double dblRK_Rational_9_40 = 9.0 / 40.0;
+    const REAL_CUDA_ARRAY RK_Rational_9_40 = ConstCUDA(dblRK_Rational_9_40);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_3_40, MulCUDA(k1_gfsL, dt), FusedMulAddCUDA(RK_Rational_9_40, MulCUDA(k2_gfsL, dt), y_n_gfsL));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * GPU Kernel: rk_substep_3_gpu.
+ * GPU Kernel to compute RK substep 3.
+ */
+__global__ static void rk_substep_3_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_3_10 = 3.0 / 10.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_10 = ConstCUDA(dblRK_Rational_3_10);
+
+    static const double dblRK_Rational_6_5 = 6.0 / 5.0;
+    const REAL_CUDA_ARRAY RK_Rational_6_5 = ConstCUDA(dblRK_Rational_6_5);
+
+    static const double dblRK_Rational_9_10 = 9.0 / 10.0;
+    const REAL_CUDA_ARRAY RK_Rational_9_10 = ConstCUDA(dblRK_Rational_9_10);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_3_10, MulCUDA(k1_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_6_5, MulCUDA(k3_gfsL, dt), NegFusedMulAddCUDA(RK_Rational_9_10, MulCUDA(k2_gfsL, dt), y_n_gfsL)));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_3_gpu
+
+/**
+ * Runge-Kutta function for substep 3.
+ */
+static void rk_substep_3__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_3_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_3_gpu failure");
+} // END FUNCTION rk_substep_3__launcher
+
+/**
+ * GPU Kernel: rk_substep_4_gpu.
+ * GPU Kernel to compute RK substep 4.
+ */
+__global__ static void rk_substep_4_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_11_54 = 11.0 / 54.0;
+    const REAL_CUDA_ARRAY RK_Rational_11_54 = ConstCUDA(dblRK_Rational_11_54);
+
+    static const double dblRK_Rational_35_27 = 35.0 / 27.0;
+    const REAL_CUDA_ARRAY RK_Rational_35_27 = ConstCUDA(dblRK_Rational_35_27);
+
+    static const double dblRK_Rational_5_2 = 5.0 / 2.0;
+    const REAL_CUDA_ARRAY RK_Rational_5_2 = ConstCUDA(dblRK_Rational_5_2);
+
+    static const double dblRK_Rational_70_27 = 70.0 / 27.0;
+    const REAL_CUDA_ARRAY RK_Rational_70_27 = ConstCUDA(dblRK_Rational_70_27);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_35_27, MulCUDA(k4_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_5_2, MulCUDA(k2_gfsL, dt),
+                                        NegFusedMulAddCUDA(RK_Rational_70_27, MulCUDA(k3_gfsL, dt),
+                                                           NegFusedMulAddCUDA(RK_Rational_11_54, MulCUDA(k1_gfsL, dt), y_n_gfsL))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_4_gpu
+
+/**
+ * Runge-Kutta function for substep 4.
+ */
+static void rk_substep_4__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_4_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, y_n_gfs, next_y_input_gfs,
+                                                                                  dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_4_gpu failure");
+} // END FUNCTION rk_substep_4__launcher
+
+/**
+ * GPU Kernel: rk_substep_5_gpu.
+ * GPU Kernel to compute RK substep 5.
+ */
+__global__ static void rk_substep_5_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1631_55296 = 1631.0 / 55296.0;
+    const REAL_CUDA_ARRAY RK_Rational_1631_55296 = ConstCUDA(dblRK_Rational_1631_55296);
+
+    static const double dblRK_Rational_175_512 = 175.0 / 512.0;
+    const REAL_CUDA_ARRAY RK_Rational_175_512 = ConstCUDA(dblRK_Rational_175_512);
+
+    static const double dblRK_Rational_253_4096 = 253.0 / 4096.0;
+    const REAL_CUDA_ARRAY RK_Rational_253_4096 = ConstCUDA(dblRK_Rational_253_4096);
+
+    static const double dblRK_Rational_44275_110592 = 44275.0 / 110592.0;
+    const REAL_CUDA_ARRAY RK_Rational_44275_110592 = ConstCUDA(dblRK_Rational_44275_110592);
+
+    static const double dblRK_Rational_575_13824 = 575.0 / 13824.0;
+    const REAL_CUDA_ARRAY RK_Rational_575_13824 = ConstCUDA(dblRK_Rational_575_13824);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_175_512, MulCUDA(k2_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_253_4096, MulCUDA(k5_gfsL, dt),
+                                        FusedMulAddCUDA(RK_Rational_44275_110592, MulCUDA(k4_gfsL, dt),
+                                                        FusedMulAddCUDA(RK_Rational_575_13824, MulCUDA(k3_gfsL, dt),
+                                                                        FusedMulAddCUDA(RK_Rational_1631_55296, MulCUDA(k1_gfsL, dt), y_n_gfsL)))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_5_gpu
+
+/**
+ * Runge-Kutta function for substep 5.
+ */
+static void rk_substep_5__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_5_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, y_n_gfs,
+                                                                                  next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_5_gpu failure");
+} // END FUNCTION rk_substep_5__launcher
+
+/**
+ * GPU Kernel: rk_substep_6_gpu.
+ * GPU Kernel to compute RK substep 6.
+ */
+__global__ static void rk_substep_6_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k4_gfs,
+                                        REAL *restrict k6_gfs, REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_125_594 = 125.0 / 594.0;
+    const REAL_CUDA_ARRAY RK_Rational_125_594 = ConstCUDA(dblRK_Rational_125_594);
+
+    static const double dblRK_Rational_250_621 = 250.0 / 621.0;
+    const REAL_CUDA_ARRAY RK_Rational_250_621 = ConstCUDA(dblRK_Rational_250_621);
+
+    static const double dblRK_Rational_37_378 = 37.0 / 378.0;
+    const REAL_CUDA_ARRAY RK_Rational_37_378 = ConstCUDA(dblRK_Rational_37_378);
+
+    static const double dblRK_Rational_512_1771 = 512.0 / 1771.0;
+    const REAL_CUDA_ARRAY RK_Rational_512_1771 = ConstCUDA(dblRK_Rational_512_1771);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_250_621, MulCUDA(k3_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_37_378, MulCUDA(k1_gfsL, dt),
+                                        FusedMulAddCUDA(RK_Rational_512_1771, MulCUDA(k6_gfsL, dt),
+                                                        FusedMulAddCUDA(RK_Rational_125_594, MulCUDA(k4_gfsL, dt), y_n_gfsL))));
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_6_gpu
+
+/**
+ * Runge-Kutta function for substep 6.
+ */
+static void rk_substep_6__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k4_gfs,
+                                   REAL *restrict k6_gfs, REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_6_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k3_gfs, k4_gfs, k6_gfs, y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_6_gpu failure");
+} // END FUNCTION rk_substep_6__launcher
+
+/**
+ * Method of Lines (MoL) for "CK5" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ CK5 }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+  // -={ START k1 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k1_gfs);
+    rk_substep_1__launcher(params, k1_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 2.00000000000000011e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k2_gfs);
+    rk_substep_2__launcher(params, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // -={ START k3 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 2.99999999999999989e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k3_gfs);
+    rk_substep_3__launcher(params, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k3 substep }=-
+
+  // -={ START k4 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 5.99999999999999978e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k4_gfs);
+    rk_substep_4__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k4 substep }=-
+
+  // -={ START k5 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k5_gfs);
+    rk_substep_5__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k5 substep }=-
+
+  // -={ START k6 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 8.75000000000000000e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k6_gfs);
+    rk_substep_6__launcher(params, k1_gfs, k3_gfs, k4_gfs, k6_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k6 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__DP5.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__DP5.cu
@@ -1,0 +1,598 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_5 = 1.0 / 5.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_5 = ConstCUDA(dblRK_Rational_1_5);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_1_5, MulCUDA(k1_gfsL, dt), y_n_gfsL);
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_3_40 = 3.0 / 40.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_40 = ConstCUDA(dblRK_Rational_3_40);
+
+    static const double dblRK_Rational_9_40 = 9.0 / 40.0;
+    const REAL_CUDA_ARRAY RK_Rational_9_40 = ConstCUDA(dblRK_Rational_9_40);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_3_40, MulCUDA(k1_gfsL, dt), FusedMulAddCUDA(RK_Rational_9_40, MulCUDA(k2_gfsL, dt), y_n_gfsL));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * GPU Kernel: rk_substep_3_gpu.
+ * GPU Kernel to compute RK substep 3.
+ */
+__global__ static void rk_substep_3_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_32_9 = 32.0 / 9.0;
+    const REAL_CUDA_ARRAY RK_Rational_32_9 = ConstCUDA(dblRK_Rational_32_9);
+
+    static const double dblRK_Rational_44_45 = 44.0 / 45.0;
+    const REAL_CUDA_ARRAY RK_Rational_44_45 = ConstCUDA(dblRK_Rational_44_45);
+
+    static const double dblRK_Rational_56_15 = 56.0 / 15.0;
+    const REAL_CUDA_ARRAY RK_Rational_56_15 = ConstCUDA(dblRK_Rational_56_15);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        RK_Rational_32_9, MulCUDA(k3_gfsL, dt),
+        FusedMulAddCUDA(RK_Rational_44_45, MulCUDA(k1_gfsL, dt), NegFusedMulAddCUDA(RK_Rational_56_15, MulCUDA(k2_gfsL, dt), y_n_gfsL)));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_3_gpu
+
+/**
+ * Runge-Kutta function for substep 3.
+ */
+static void rk_substep_3__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_3_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_3_gpu failure");
+} // END FUNCTION rk_substep_3__launcher
+
+/**
+ * GPU Kernel: rk_substep_4_gpu.
+ * GPU Kernel to compute RK substep 4.
+ */
+__global__ static void rk_substep_4_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_19372_6561 = 19372.0 / 6561.0;
+    const REAL_CUDA_ARRAY RK_Rational_19372_6561 = ConstCUDA(dblRK_Rational_19372_6561);
+
+    static const double dblRK_Rational_212_729 = 212.0 / 729.0;
+    const REAL_CUDA_ARRAY RK_Rational_212_729 = ConstCUDA(dblRK_Rational_212_729);
+
+    static const double dblRK_Rational_25360_2187 = 25360.0 / 2187.0;
+    const REAL_CUDA_ARRAY RK_Rational_25360_2187 = ConstCUDA(dblRK_Rational_25360_2187);
+
+    static const double dblRK_Rational_64448_6561 = 64448.0 / 6561.0;
+    const REAL_CUDA_ARRAY RK_Rational_64448_6561 = ConstCUDA(dblRK_Rational_64448_6561);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_19372_6561, MulCUDA(k1_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_64448_6561, MulCUDA(k3_gfsL, dt),
+                                        NegFusedMulAddCUDA(RK_Rational_25360_2187, MulCUDA(k2_gfsL, dt),
+                                                           NegFusedMulAddCUDA(RK_Rational_212_729, MulCUDA(k4_gfsL, dt), y_n_gfsL))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_4_gpu
+
+/**
+ * Runge-Kutta function for substep 4.
+ */
+static void rk_substep_4__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_4_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, y_n_gfs, next_y_input_gfs,
+                                                                                  dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_4_gpu failure");
+} // END FUNCTION rk_substep_4__launcher
+
+/**
+ * GPU Kernel: rk_substep_5_gpu.
+ * GPU Kernel to compute RK substep 5.
+ */
+__global__ static void rk_substep_5_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_355_33 = 355.0 / 33.0;
+    const REAL_CUDA_ARRAY RK_Rational_355_33 = ConstCUDA(dblRK_Rational_355_33);
+
+    static const double dblRK_Rational_46732_5247 = 46732.0 / 5247.0;
+    const REAL_CUDA_ARRAY RK_Rational_46732_5247 = ConstCUDA(dblRK_Rational_46732_5247);
+
+    static const double dblRK_Rational_49_176 = 49.0 / 176.0;
+    const REAL_CUDA_ARRAY RK_Rational_49_176 = ConstCUDA(dblRK_Rational_49_176);
+
+    static const double dblRK_Rational_5103_18656 = 5103.0 / 18656.0;
+    const REAL_CUDA_ARRAY RK_Rational_5103_18656 = ConstCUDA(dblRK_Rational_5103_18656);
+
+    static const double dblRK_Rational_9017_3168 = 9017.0 / 3168.0;
+    const REAL_CUDA_ARRAY RK_Rational_9017_3168 = ConstCUDA(dblRK_Rational_9017_3168);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_9017_3168, MulCUDA(k1_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_46732_5247, MulCUDA(k3_gfsL, dt),
+                                        FusedMulAddCUDA(RK_Rational_49_176, MulCUDA(k4_gfsL, dt),
+                                                        NegFusedMulAddCUDA(RK_Rational_5103_18656, MulCUDA(k5_gfsL, dt),
+                                                                           NegFusedMulAddCUDA(RK_Rational_355_33, MulCUDA(k2_gfsL, dt), y_n_gfsL)))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_5_gpu
+
+/**
+ * Runge-Kutta function for substep 5.
+ */
+static void rk_substep_5__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_5_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, y_n_gfs,
+                                                                                  next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_5_gpu failure");
+} // END FUNCTION rk_substep_5__launcher
+
+/**
+ * GPU Kernel: rk_substep_6_gpu.
+ * GPU Kernel to compute RK substep 6.
+ */
+__global__ static void rk_substep_6_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k4_gfs,
+                                        REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_11_84 = 11.0 / 84.0;
+    const REAL_CUDA_ARRAY RK_Rational_11_84 = ConstCUDA(dblRK_Rational_11_84);
+
+    static const double dblRK_Rational_125_192 = 125.0 / 192.0;
+    const REAL_CUDA_ARRAY RK_Rational_125_192 = ConstCUDA(dblRK_Rational_125_192);
+
+    static const double dblRK_Rational_2187_6784 = 2187.0 / 6784.0;
+    const REAL_CUDA_ARRAY RK_Rational_2187_6784 = ConstCUDA(dblRK_Rational_2187_6784);
+
+    static const double dblRK_Rational_35_384 = 35.0 / 384.0;
+    const REAL_CUDA_ARRAY RK_Rational_35_384 = ConstCUDA(dblRK_Rational_35_384);
+
+    static const double dblRK_Rational_500_1113 = 500.0 / 1113.0;
+    const REAL_CUDA_ARRAY RK_Rational_500_1113 = ConstCUDA(dblRK_Rational_500_1113);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_35_384, MulCUDA(k1_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_11_84, MulCUDA(k6_gfsL, dt),
+                                        FusedMulAddCUDA(RK_Rational_125_192, MulCUDA(k4_gfsL, dt),
+                                                        FusedMulAddCUDA(RK_Rational_500_1113, MulCUDA(k3_gfsL, dt),
+                                                                        NegFusedMulAddCUDA(RK_Rational_2187_6784, MulCUDA(k5_gfsL, dt), y_n_gfsL)))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_6_gpu
+
+/**
+ * Runge-Kutta function for substep 6.
+ */
+static void rk_substep_6__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k4_gfs,
+                                   REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_6_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs,
+                                                                                  next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_6_gpu failure");
+} // END FUNCTION rk_substep_6__launcher
+
+/**
+ * GPU Kernel: rk_substep_7_gpu.
+ * GPU Kernel to compute RK substep 7.
+ */
+__global__ static void rk_substep_7_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k4_gfs,
+                                        REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_11_84 = 11.0 / 84.0;
+    const REAL_CUDA_ARRAY RK_Rational_11_84 = ConstCUDA(dblRK_Rational_11_84);
+
+    static const double dblRK_Rational_125_192 = 125.0 / 192.0;
+    const REAL_CUDA_ARRAY RK_Rational_125_192 = ConstCUDA(dblRK_Rational_125_192);
+
+    static const double dblRK_Rational_2187_6784 = 2187.0 / 6784.0;
+    const REAL_CUDA_ARRAY RK_Rational_2187_6784 = ConstCUDA(dblRK_Rational_2187_6784);
+
+    static const double dblRK_Rational_35_384 = 35.0 / 384.0;
+    const REAL_CUDA_ARRAY RK_Rational_35_384 = ConstCUDA(dblRK_Rational_35_384);
+
+    static const double dblRK_Rational_500_1113 = 500.0 / 1113.0;
+    const REAL_CUDA_ARRAY RK_Rational_500_1113 = ConstCUDA(dblRK_Rational_500_1113);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_35_384, MulCUDA(k1_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_11_84, MulCUDA(k6_gfsL, dt),
+                                        FusedMulAddCUDA(RK_Rational_125_192, MulCUDA(k4_gfsL, dt),
+                                                        FusedMulAddCUDA(RK_Rational_500_1113, MulCUDA(k3_gfsL, dt),
+                                                                        NegFusedMulAddCUDA(RK_Rational_2187_6784, MulCUDA(k5_gfsL, dt), y_n_gfsL)))));
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_7_gpu
+
+/**
+ * Runge-Kutta function for substep 7.
+ */
+static void rk_substep_7__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k4_gfs,
+                                   REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_7_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_7_gpu failure");
+} // END FUNCTION rk_substep_7__launcher
+
+/**
+ * Method of Lines (MoL) for "DP5" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ DP5 }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+  // -={ START k1 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k1_gfs);
+    rk_substep_1__launcher(params, k1_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 2.00000000000000011e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k2_gfs);
+    rk_substep_2__launcher(params, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // -={ START k3 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 2.99999999999999989e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k3_gfs);
+    rk_substep_3__launcher(params, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k3 substep }=-
+
+  // -={ START k4 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 8.00000000000000044e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k4_gfs);
+    rk_substep_4__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k4 substep }=-
+
+  // -={ START k5 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 8.88888888888888840e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k5_gfs);
+    rk_substep_5__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k5 substep }=-
+
+  // -={ START k6 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k6_gfs);
+    rk_substep_6__launcher(params, k1_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k6 substep }=-
+
+  // -={ START k7 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k7_gfs);
+    rk_substep_7__launcher(params, k1_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k7 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__DP5alt.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__DP5alt.cu
@@ -1,0 +1,611 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_10 = 1.0 / 10.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_10 = ConstCUDA(dblRK_Rational_1_10);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_1_10, MulCUDA(k1_gfsL, dt), y_n_gfsL);
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_20_81 = 20.0 / 81.0;
+    const REAL_CUDA_ARRAY RK_Rational_20_81 = ConstCUDA(dblRK_Rational_20_81);
+
+    static const double dblRK_Rational_2_81 = 2.0 / 81.0;
+    const REAL_CUDA_ARRAY RK_Rational_2_81 = ConstCUDA(dblRK_Rational_2_81);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_20_81, MulCUDA(k2_gfsL, dt), NegFusedMulAddCUDA(RK_Rational_2_81, MulCUDA(k1_gfsL, dt), y_n_gfsL));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * GPU Kernel: rk_substep_3_gpu.
+ * GPU Kernel to compute RK substep 3.
+ */
+__global__ static void rk_substep_3_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_1053_1372 = 1053.0 / 1372.0;
+    const REAL_CUDA_ARRAY RK_Rational_1053_1372 = ConstCUDA(dblRK_Rational_1053_1372);
+
+    static const double dblRK_Rational_270_343 = 270.0 / 343.0;
+    const REAL_CUDA_ARRAY RK_Rational_270_343 = ConstCUDA(dblRK_Rational_270_343);
+
+    static const double dblRK_Rational_615_1372 = 615.0 / 1372.0;
+    const REAL_CUDA_ARRAY RK_Rational_615_1372 = ConstCUDA(dblRK_Rational_615_1372);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        RK_Rational_1053_1372, MulCUDA(k3_gfsL, dt),
+        FusedMulAddCUDA(RK_Rational_615_1372, MulCUDA(k1_gfsL, dt), NegFusedMulAddCUDA(RK_Rational_270_343, MulCUDA(k2_gfsL, dt), y_n_gfsL)));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_3_gpu
+
+/**
+ * Runge-Kutta function for substep 3.
+ */
+static void rk_substep_3__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_3_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_3_gpu failure");
+} // END FUNCTION rk_substep_3__launcher
+
+/**
+ * GPU Kernel: rk_substep_4_gpu.
+ * GPU Kernel to compute RK substep 4.
+ */
+__global__ static void rk_substep_4_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_3243_5500 = 3243.0 / 5500.0;
+    const REAL_CUDA_ARRAY RK_Rational_3243_5500 = ConstCUDA(dblRK_Rational_3243_5500);
+
+    static const double dblRK_Rational_4998_17875 = 4998.0 / 17875.0;
+    const REAL_CUDA_ARRAY RK_Rational_4998_17875 = ConstCUDA(dblRK_Rational_4998_17875);
+
+    static const double dblRK_Rational_50949_71500 = 50949.0 / 71500.0;
+    const REAL_CUDA_ARRAY RK_Rational_50949_71500 = ConstCUDA(dblRK_Rational_50949_71500);
+
+    static const double dblRK_Rational_54_55 = 54.0 / 55.0;
+    const REAL_CUDA_ARRAY RK_Rational_54_55 = ConstCUDA(dblRK_Rational_54_55);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_3243_5500, MulCUDA(k1_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_4998_17875, MulCUDA(k4_gfsL, dt),
+                                        FusedMulAddCUDA(RK_Rational_50949_71500, MulCUDA(k3_gfsL, dt),
+                                                        NegFusedMulAddCUDA(RK_Rational_54_55, MulCUDA(k2_gfsL, dt), y_n_gfsL))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_4_gpu
+
+/**
+ * Runge-Kutta function for substep 4.
+ */
+static void rk_substep_4__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_4_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, y_n_gfs, next_y_input_gfs,
+                                                                                  dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_4_gpu failure");
+} // END FUNCTION rk_substep_4__launcher
+
+/**
+ * GPU Kernel: rk_substep_5_gpu.
+ * GPU Kernel to compute RK substep 5.
+ */
+__global__ static void rk_substep_5_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_24206_37125 = 24206.0 / 37125.0;
+    const REAL_CUDA_ARRAY RK_Rational_24206_37125 = ConstCUDA(dblRK_Rational_24206_37125);
+
+    static const double dblRK_Rational_26492_37125 = 26492.0 / 37125.0;
+    const REAL_CUDA_ARRAY RK_Rational_26492_37125 = ConstCUDA(dblRK_Rational_26492_37125);
+
+    static const double dblRK_Rational_2808_23375 = 2808.0 / 23375.0;
+    const REAL_CUDA_ARRAY RK_Rational_2808_23375 = ConstCUDA(dblRK_Rational_2808_23375);
+
+    static const double dblRK_Rational_338_459 = 338.0 / 459.0;
+    const REAL_CUDA_ARRAY RK_Rational_338_459 = ConstCUDA(dblRK_Rational_338_459);
+
+    static const double dblRK_Rational_72_55 = 72.0 / 55.0;
+    const REAL_CUDA_ARRAY RK_Rational_72_55 = ConstCUDA(dblRK_Rational_72_55);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        RK_Rational_72_55, MulCUDA(k2_gfsL, dt),
+        FusedMulAddCUDA(RK_Rational_2808_23375, MulCUDA(k3_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_338_459, MulCUDA(k5_gfsL, dt),
+                                        NegFusedMulAddCUDA(RK_Rational_26492_37125, MulCUDA(k1_gfsL, dt),
+                                                           NegFusedMulAddCUDA(RK_Rational_24206_37125, MulCUDA(k4_gfsL, dt), y_n_gfsL)))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_5_gpu
+
+/**
+ * Runge-Kutta function for substep 5.
+ */
+static void rk_substep_5__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_5_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, y_n_gfs,
+                                                                                  next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_5_gpu failure");
+} // END FUNCTION rk_substep_5__launcher
+
+/**
+ * GPU Kernel: rk_substep_6_gpu.
+ * GPU Kernel to compute RK substep 6.
+ */
+__global__ static void rk_substep_6_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_24117_31603 = 24117.0 / 31603.0;
+    const REAL_CUDA_ARRAY RK_Rational_24117_31603 = ConstCUDA(dblRK_Rational_24117_31603);
+
+    static const double dblRK_Rational_35_11 = 35.0 / 11.0;
+    const REAL_CUDA_ARRAY RK_Rational_35_11 = ConstCUDA(dblRK_Rational_35_11);
+
+    static const double dblRK_Rational_3925_4056 = 3925.0 / 4056.0;
+    const REAL_CUDA_ARRAY RK_Rational_3925_4056 = ConstCUDA(dblRK_Rational_3925_4056);
+
+    static const double dblRK_Rational_5225_1836 = 5225.0 / 1836.0;
+    const REAL_CUDA_ARRAY RK_Rational_5225_1836 = ConstCUDA(dblRK_Rational_5225_1836);
+
+    static const double dblRK_Rational_5561_2376 = 5561.0 / 2376.0;
+    const REAL_CUDA_ARRAY RK_Rational_5561_2376 = ConstCUDA(dblRK_Rational_5561_2376);
+
+    static const double dblRK_Rational_899983_200772 = 899983.0 / 200772.0;
+    const REAL_CUDA_ARRAY RK_Rational_899983_200772 = ConstCUDA(dblRK_Rational_899983_200772);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        RK_Rational_899983_200772, MulCUDA(k4_gfsL, dt),
+        NegFusedMulAddCUDA(
+            RK_Rational_35_11, MulCUDA(k2_gfsL, dt),
+            FusedMulAddCUDA(RK_Rational_3925_4056, MulCUDA(k6_gfsL, dt),
+                            FusedMulAddCUDA(RK_Rational_5561_2376, MulCUDA(k1_gfsL, dt),
+                                            NegFusedMulAddCUDA(RK_Rational_5225_1836, MulCUDA(k5_gfsL, dt),
+                                                               NegFusedMulAddCUDA(RK_Rational_24117_31603, MulCUDA(k3_gfsL, dt), y_n_gfsL))))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_6_gpu
+
+/**
+ * Runge-Kutta function for substep 6.
+ */
+static void rk_substep_6__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_6_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs,
+                                                                                  next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_6_gpu failure");
+} // END FUNCTION rk_substep_6__launcher
+
+/**
+ * GPU Kernel: rk_substep_7_gpu.
+ * GPU Kernel to compute RK substep 7.
+ */
+__global__ static void rk_substep_7_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k4_gfs,
+                                        REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL k7_gfsL = k7_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_175273_912600 = 175273.0 / 912600.0;
+    const REAL_CUDA_ARRAY RK_Rational_175273_912600 = ConstCUDA(dblRK_Rational_175273_912600);
+
+    static const double dblRK_Rational_19683_71825 = 19683.0 / 71825.0;
+    const REAL_CUDA_ARRAY RK_Rational_19683_71825 = ConstCUDA(dblRK_Rational_19683_71825);
+
+    static const double dblRK_Rational_395_3672 = 395.0 / 3672.0;
+    const REAL_CUDA_ARRAY RK_Rational_395_3672 = ConstCUDA(dblRK_Rational_395_3672);
+
+    static const double dblRK_Rational_3_50 = 3.0 / 50.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_50 = ConstCUDA(dblRK_Rational_3_50);
+
+    static const double dblRK_Rational_785_2704 = 785.0 / 2704.0;
+    const REAL_CUDA_ARRAY RK_Rational_785_2704 = ConstCUDA(dblRK_Rational_785_2704);
+
+    static const double dblRK_Rational_821_10800 = 821.0 / 10800.0;
+    const REAL_CUDA_ARRAY RK_Rational_821_10800 = ConstCUDA(dblRK_Rational_821_10800);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        RK_Rational_3_50, MulCUDA(k7_gfsL, dt),
+        FusedMulAddCUDA(
+            RK_Rational_19683_71825, MulCUDA(k3_gfsL, dt),
+            FusedMulAddCUDA(RK_Rational_395_3672, MulCUDA(k5_gfsL, dt),
+                            FusedMulAddCUDA(RK_Rational_785_2704, MulCUDA(k6_gfsL, dt),
+                                            FusedMulAddCUDA(RK_Rational_821_10800, MulCUDA(k1_gfsL, dt),
+                                                            FusedMulAddCUDA(RK_Rational_175273_912600, MulCUDA(k4_gfsL, dt), y_n_gfsL))))));
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_7_gpu
+
+/**
+ * Runge-Kutta function for substep 7.
+ */
+static void rk_substep_7__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k4_gfs,
+                                   REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_7_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, y_n_gfs,
+                                                                                  dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_7_gpu failure");
+} // END FUNCTION rk_substep_7__launcher
+
+/**
+ * Method of Lines (MoL) for "DP5alt" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ DP5alt }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+  // -={ START k1 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k1_gfs);
+    rk_substep_1__launcher(params, k1_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000006e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k2_gfs);
+    rk_substep_2__launcher(params, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // -={ START k3 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 2.22222222222222210e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k3_gfs);
+    rk_substep_3__launcher(params, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k3 substep }=-
+
+  // -={ START k4 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 4.28571428571428548e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k4_gfs);
+    rk_substep_4__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k4 substep }=-
+
+  // -={ START k5 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 5.99999999999999978e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k5_gfs);
+    rk_substep_5__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k5 substep }=-
+
+  // -={ START k6 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 8.00000000000000044e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k6_gfs);
+    rk_substep_6__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k6 substep }=-
+
+  // -={ START k7 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k7_gfs);
+    rk_substep_7__launcher(params, k1_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k7 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__DP6.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__DP6.cu
@@ -1,0 +1,727 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_10 = 1.0 / 10.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_10 = ConstCUDA(dblRK_Rational_1_10);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_1_10, MulCUDA(k1_gfsL, dt), y_n_gfsL);
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_20_81 = 20.0 / 81.0;
+    const REAL_CUDA_ARRAY RK_Rational_20_81 = ConstCUDA(dblRK_Rational_20_81);
+
+    static const double dblRK_Rational_2_81 = 2.0 / 81.0;
+    const REAL_CUDA_ARRAY RK_Rational_2_81 = ConstCUDA(dblRK_Rational_2_81);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_20_81, MulCUDA(k2_gfsL, dt), NegFusedMulAddCUDA(RK_Rational_2_81, MulCUDA(k1_gfsL, dt), y_n_gfsL));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * GPU Kernel: rk_substep_3_gpu.
+ * GPU Kernel to compute RK substep 3.
+ */
+__global__ static void rk_substep_3_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_1053_1372 = 1053.0 / 1372.0;
+    const REAL_CUDA_ARRAY RK_Rational_1053_1372 = ConstCUDA(dblRK_Rational_1053_1372);
+
+    static const double dblRK_Rational_270_343 = 270.0 / 343.0;
+    const REAL_CUDA_ARRAY RK_Rational_270_343 = ConstCUDA(dblRK_Rational_270_343);
+
+    static const double dblRK_Rational_615_1372 = 615.0 / 1372.0;
+    const REAL_CUDA_ARRAY RK_Rational_615_1372 = ConstCUDA(dblRK_Rational_615_1372);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        RK_Rational_1053_1372, MulCUDA(k3_gfsL, dt),
+        FusedMulAddCUDA(RK_Rational_615_1372, MulCUDA(k1_gfsL, dt), NegFusedMulAddCUDA(RK_Rational_270_343, MulCUDA(k2_gfsL, dt), y_n_gfsL)));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_3_gpu
+
+/**
+ * Runge-Kutta function for substep 3.
+ */
+static void rk_substep_3__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_3_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_3_gpu failure");
+} // END FUNCTION rk_substep_3__launcher
+
+/**
+ * GPU Kernel: rk_substep_4_gpu.
+ * GPU Kernel to compute RK substep 4.
+ */
+__global__ static void rk_substep_4_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_3243_5500 = 3243.0 / 5500.0;
+    const REAL_CUDA_ARRAY RK_Rational_3243_5500 = ConstCUDA(dblRK_Rational_3243_5500);
+
+    static const double dblRK_Rational_4998_17875 = 4998.0 / 17875.0;
+    const REAL_CUDA_ARRAY RK_Rational_4998_17875 = ConstCUDA(dblRK_Rational_4998_17875);
+
+    static const double dblRK_Rational_50949_71500 = 50949.0 / 71500.0;
+    const REAL_CUDA_ARRAY RK_Rational_50949_71500 = ConstCUDA(dblRK_Rational_50949_71500);
+
+    static const double dblRK_Rational_54_55 = 54.0 / 55.0;
+    const REAL_CUDA_ARRAY RK_Rational_54_55 = ConstCUDA(dblRK_Rational_54_55);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_3243_5500, MulCUDA(k1_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_4998_17875, MulCUDA(k4_gfsL, dt),
+                                        FusedMulAddCUDA(RK_Rational_50949_71500, MulCUDA(k3_gfsL, dt),
+                                                        NegFusedMulAddCUDA(RK_Rational_54_55, MulCUDA(k2_gfsL, dt), y_n_gfsL))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_4_gpu
+
+/**
+ * Runge-Kutta function for substep 4.
+ */
+static void rk_substep_4__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_4_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, y_n_gfs, next_y_input_gfs,
+                                                                                  dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_4_gpu failure");
+} // END FUNCTION rk_substep_4__launcher
+
+/**
+ * GPU Kernel: rk_substep_5_gpu.
+ * GPU Kernel to compute RK substep 5.
+ */
+__global__ static void rk_substep_5_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_24206_37125 = 24206.0 / 37125.0;
+    const REAL_CUDA_ARRAY RK_Rational_24206_37125 = ConstCUDA(dblRK_Rational_24206_37125);
+
+    static const double dblRK_Rational_26492_37125 = 26492.0 / 37125.0;
+    const REAL_CUDA_ARRAY RK_Rational_26492_37125 = ConstCUDA(dblRK_Rational_26492_37125);
+
+    static const double dblRK_Rational_2808_23375 = 2808.0 / 23375.0;
+    const REAL_CUDA_ARRAY RK_Rational_2808_23375 = ConstCUDA(dblRK_Rational_2808_23375);
+
+    static const double dblRK_Rational_338_459 = 338.0 / 459.0;
+    const REAL_CUDA_ARRAY RK_Rational_338_459 = ConstCUDA(dblRK_Rational_338_459);
+
+    static const double dblRK_Rational_72_55 = 72.0 / 55.0;
+    const REAL_CUDA_ARRAY RK_Rational_72_55 = ConstCUDA(dblRK_Rational_72_55);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        RK_Rational_72_55, MulCUDA(k2_gfsL, dt),
+        FusedMulAddCUDA(RK_Rational_2808_23375, MulCUDA(k3_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_338_459, MulCUDA(k5_gfsL, dt),
+                                        NegFusedMulAddCUDA(RK_Rational_26492_37125, MulCUDA(k1_gfsL, dt),
+                                                           NegFusedMulAddCUDA(RK_Rational_24206_37125, MulCUDA(k4_gfsL, dt), y_n_gfsL)))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_5_gpu
+
+/**
+ * Runge-Kutta function for substep 5.
+ */
+static void rk_substep_5__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_5_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, y_n_gfs,
+                                                                                  next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_5_gpu failure");
+} // END FUNCTION rk_substep_5__launcher
+
+/**
+ * GPU Kernel: rk_substep_6_gpu.
+ * GPU Kernel to compute RK substep 6.
+ */
+__global__ static void rk_substep_6_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_24117_31603 = 24117.0 / 31603.0;
+    const REAL_CUDA_ARRAY RK_Rational_24117_31603 = ConstCUDA(dblRK_Rational_24117_31603);
+
+    static const double dblRK_Rational_35_11 = 35.0 / 11.0;
+    const REAL_CUDA_ARRAY RK_Rational_35_11 = ConstCUDA(dblRK_Rational_35_11);
+
+    static const double dblRK_Rational_3925_4056 = 3925.0 / 4056.0;
+    const REAL_CUDA_ARRAY RK_Rational_3925_4056 = ConstCUDA(dblRK_Rational_3925_4056);
+
+    static const double dblRK_Rational_5225_1836 = 5225.0 / 1836.0;
+    const REAL_CUDA_ARRAY RK_Rational_5225_1836 = ConstCUDA(dblRK_Rational_5225_1836);
+
+    static const double dblRK_Rational_5561_2376 = 5561.0 / 2376.0;
+    const REAL_CUDA_ARRAY RK_Rational_5561_2376 = ConstCUDA(dblRK_Rational_5561_2376);
+
+    static const double dblRK_Rational_899983_200772 = 899983.0 / 200772.0;
+    const REAL_CUDA_ARRAY RK_Rational_899983_200772 = ConstCUDA(dblRK_Rational_899983_200772);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        RK_Rational_899983_200772, MulCUDA(k4_gfsL, dt),
+        NegFusedMulAddCUDA(
+            RK_Rational_35_11, MulCUDA(k2_gfsL, dt),
+            FusedMulAddCUDA(RK_Rational_3925_4056, MulCUDA(k6_gfsL, dt),
+                            FusedMulAddCUDA(RK_Rational_5561_2376, MulCUDA(k1_gfsL, dt),
+                                            NegFusedMulAddCUDA(RK_Rational_5225_1836, MulCUDA(k5_gfsL, dt),
+                                                               NegFusedMulAddCUDA(RK_Rational_24117_31603, MulCUDA(k3_gfsL, dt), y_n_gfsL))))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_6_gpu
+
+/**
+ * Runge-Kutta function for substep 6.
+ */
+static void rk_substep_6__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_6_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs,
+                                                                                  next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_6_gpu failure");
+} // END FUNCTION rk_substep_6__launcher
+
+/**
+ * GPU Kernel: rk_substep_7_gpu.
+ * GPU Kernel to compute RK substep 7.
+ */
+__global__ static void rk_substep_7_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_10513573_3212352 = 10513573.0 / 3212352.0;
+    const REAL_CUDA_ARRAY RK_Rational_10513573_3212352 = ConstCUDA(dblRK_Rational_10513573_3212352);
+
+    static const double dblRK_Rational_2945_1232 = 2945.0 / 1232.0;
+    const REAL_CUDA_ARRAY RK_Rational_2945_1232 = ConstCUDA(dblRK_Rational_2945_1232);
+
+    static const double dblRK_Rational_376225_454272 = 376225.0 / 454272.0;
+    const REAL_CUDA_ARRAY RK_Rational_376225_454272 = ConstCUDA(dblRK_Rational_376225_454272);
+
+    static const double dblRK_Rational_424325_205632 = 424325.0 / 205632.0;
+    const REAL_CUDA_ARRAY RK_Rational_424325_205632 = ConstCUDA(dblRK_Rational_424325_205632);
+
+    static const double dblRK_Rational_465467_266112 = 465467.0 / 266112.0;
+    const REAL_CUDA_ARRAY RK_Rational_465467_266112 = ConstCUDA(dblRK_Rational_465467_266112);
+
+    static const double dblRK_Rational_5610201_14158144 = 5610201.0 / 14158144.0;
+    const REAL_CUDA_ARRAY RK_Rational_5610201_14158144 = ConstCUDA(dblRK_Rational_5610201_14158144);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        RK_Rational_465467_266112, MulCUDA(k1_gfsL, dt),
+        NegFusedMulAddCUDA(
+            RK_Rational_424325_205632, MulCUDA(k5_gfsL, dt),
+            FusedMulAddCUDA(RK_Rational_10513573_3212352, MulCUDA(k4_gfsL, dt),
+                            FusedMulAddCUDA(RK_Rational_376225_454272, MulCUDA(k6_gfsL, dt),
+                                            NegFusedMulAddCUDA(RK_Rational_5610201_14158144, MulCUDA(k3_gfsL, dt),
+                                                               NegFusedMulAddCUDA(RK_Rational_2945_1232, MulCUDA(k2_gfsL, dt), y_n_gfsL))))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_7_gpu
+
+/**
+ * Runge-Kutta function for substep 7.
+ */
+static void rk_substep_7__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_7_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs,
+                                                                                  next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_7_gpu failure");
+} // END FUNCTION rk_substep_7__launcher
+
+/**
+ * GPU Kernel: rk_substep_8_gpu.
+ * GPU Kernel to compute RK substep 8.
+ */
+__global__ static void rk_substep_8_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k4_gfs,
+                                        REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict k8_gfs,
+                                        REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL k7_gfsL = k7_gfs[i];
+    const REAL k8_gfsL = k8_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_1375_5408 = 1375.0 / 5408.0;
+    const REAL_CUDA_ARRAY RK_Rational_1375_5408 = ConstCUDA(dblRK_Rational_1375_5408);
+
+    static const double dblRK_Rational_1375_7344 = 1375.0 / 7344.0;
+    const REAL_CUDA_ARRAY RK_Rational_1375_7344 = ConstCUDA(dblRK_Rational_1375_7344);
+
+    static const double dblRK_Rational_16807_146016 = 16807.0 / 146016.0;
+    const REAL_CUDA_ARRAY RK_Rational_16807_146016 = ConstCUDA(dblRK_Rational_16807_146016);
+
+    static const double dblRK_Rational_1_10 = 1.0 / 10.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_10 = ConstCUDA(dblRK_Rational_1_10);
+
+    static const double dblRK_Rational_37_1120 = 37.0 / 1120.0;
+    const REAL_CUDA_ARRAY RK_Rational_37_1120 = ConstCUDA(dblRK_Rational_37_1120);
+
+    static const double dblRK_Rational_61_864 = 61.0 / 864.0;
+    const REAL_CUDA_ARRAY RK_Rational_61_864 = ConstCUDA(dblRK_Rational_61_864);
+
+    static const double dblRK_Rational_98415_321776 = 98415.0 / 321776.0;
+    const REAL_CUDA_ARRAY RK_Rational_98415_321776 = ConstCUDA(dblRK_Rational_98415_321776);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        RK_Rational_61_864, MulCUDA(k1_gfsL, dt),
+        FusedMulAddCUDA(RK_Rational_16807_146016, MulCUDA(k4_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_1_10, MulCUDA(k8_gfsL, dt),
+                                        FusedMulAddCUDA(RK_Rational_1375_5408, MulCUDA(k6_gfsL, dt),
+                                                        FusedMulAddCUDA(RK_Rational_1375_7344, MulCUDA(k5_gfsL, dt),
+                                                                        FusedMulAddCUDA(RK_Rational_98415_321776, MulCUDA(k3_gfsL, dt),
+                                                                                        NegFusedMulAddCUDA(RK_Rational_37_1120, MulCUDA(k7_gfsL, dt),
+                                                                                                           y_n_gfsL)))))));
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_8_gpu
+
+/**
+ * Runge-Kutta function for substep 8.
+ */
+static void rk_substep_8__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k4_gfs,
+                                   REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict k8_gfs, REAL *restrict y_n_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_8_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, k8_gfs,
+                                                                                  y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_8_gpu failure");
+} // END FUNCTION rk_substep_8__launcher
+
+/**
+ * Method of Lines (MoL) for "DP6" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ DP6 }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+  // -={ START k1 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k1_gfs);
+    rk_substep_1__launcher(params, k1_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000006e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k2_gfs);
+    rk_substep_2__launcher(params, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // -={ START k3 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 2.22222222222222210e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k3_gfs);
+    rk_substep_3__launcher(params, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k3 substep }=-
+
+  // -={ START k4 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 4.28571428571428548e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k4_gfs);
+    rk_substep_4__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k4 substep }=-
+
+  // -={ START k5 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 5.99999999999999978e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k5_gfs);
+    rk_substep_5__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k5 substep }=-
+
+  // -={ START k6 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 8.00000000000000044e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k6_gfs);
+    rk_substep_6__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k6 substep }=-
+
+  // -={ START k7 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k7_gfs);
+    rk_substep_7__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k7 substep }=-
+
+  // -={ START k8 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k8_gfs);
+    rk_substep_8__launcher(params, k1_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, k8_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k8 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__DP8.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__DP8.cu
@@ -1,0 +1,1299 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_18 = 1.0 / 18.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_18 = ConstCUDA(dblRK_Rational_1_18);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_1_18, MulCUDA(k1_gfsL, dt), y_n_gfsL);
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_16 = 1.0 / 16.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_16 = ConstCUDA(dblRK_Rational_1_16);
+
+    static const double dblRK_Rational_1_48 = 1.0 / 48.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_48 = ConstCUDA(dblRK_Rational_1_48);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_1_16, MulCUDA(k2_gfsL, dt), FusedMulAddCUDA(RK_Rational_1_48, MulCUDA(k1_gfsL, dt), y_n_gfsL));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * GPU Kernel: rk_substep_3_gpu.
+ * GPU Kernel to compute RK substep 3.
+ */
+__global__ static void rk_substep_3_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_32 = 1.0 / 32.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_32 = ConstCUDA(dblRK_Rational_1_32);
+
+    static const double dblRK_Rational_3_32 = 3.0 / 32.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_32 = ConstCUDA(dblRK_Rational_3_32);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_1_32, MulCUDA(k1_gfsL, dt), FusedMulAddCUDA(RK_Rational_3_32, MulCUDA(k3_gfsL, dt), y_n_gfsL));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_3_gpu
+
+/**
+ * Runge-Kutta function for substep 3.
+ */
+static void rk_substep_3__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_3_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k3_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_3_gpu failure");
+} // END FUNCTION rk_substep_3__launcher
+
+/**
+ * GPU Kernel: rk_substep_4_gpu.
+ * GPU Kernel to compute RK substep 4.
+ */
+__global__ static void rk_substep_4_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k4_gfs,
+                                        REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_5_16 = 5.0 / 16.0;
+    const REAL_CUDA_ARRAY RK_Rational_5_16 = ConstCUDA(dblRK_Rational_5_16);
+
+    static const double dblRK_Rational_75_64 = 75.0 / 64.0;
+    const REAL_CUDA_ARRAY RK_Rational_75_64 = ConstCUDA(dblRK_Rational_75_64);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_75_64, FusedMulSubCUDA(k4_gfsL, dt, MulCUDA(k3_gfsL, dt)),
+                                                       FusedMulAddCUDA(RK_Rational_5_16, MulCUDA(k1_gfsL, dt), y_n_gfsL));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_4_gpu
+
+/**
+ * Runge-Kutta function for substep 4.
+ */
+static void rk_substep_4__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k4_gfs,
+                                   REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_4_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k3_gfs, k4_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_4_gpu failure");
+} // END FUNCTION rk_substep_4__launcher
+
+/**
+ * GPU Kernel: rk_substep_5_gpu.
+ * GPU Kernel to compute RK substep 5.
+ */
+__global__ static void rk_substep_5_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k4_gfs, REAL *restrict k5_gfs,
+                                        REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_3_16 = 3.0 / 16.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_16 = ConstCUDA(dblRK_Rational_3_16);
+
+    static const double dblRK_Rational_3_20 = 3.0 / 20.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_20 = ConstCUDA(dblRK_Rational_3_20);
+
+    static const double dblRK_Rational_3_80 = 3.0 / 80.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_80 = ConstCUDA(dblRK_Rational_3_80);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_3_20, MulCUDA(k5_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_3_80, MulCUDA(k1_gfsL, dt), FusedMulAddCUDA(RK_Rational_3_16, MulCUDA(k4_gfsL, dt), y_n_gfsL)));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_5_gpu
+
+/**
+ * Runge-Kutta function for substep 5.
+ */
+static void rk_substep_5__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k4_gfs, REAL *restrict k5_gfs,
+                                   REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_5_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k4_gfs, k5_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_5_gpu failure");
+} // END FUNCTION rk_substep_5__launcher
+
+/**
+ * GPU Kernel: rk_substep_6_gpu.
+ * GPU Kernel to compute RK substep 6.
+ */
+__global__ static void rk_substep_6_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k4_gfs, REAL *restrict k5_gfs,
+                                        REAL *restrict k6_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_23124283_1800000000 = 23124283.0 / 1800000000.0;
+    const REAL_CUDA_ARRAY RK_Rational_23124283_1800000000 = ConstCUDA(dblRK_Rational_23124283_1800000000);
+
+    static const double dblRK_Rational_28693883_1125000000 = 28693883.0 / 1125000000.0;
+    const REAL_CUDA_ARRAY RK_Rational_28693883_1125000000 = ConstCUDA(dblRK_Rational_28693883_1125000000);
+
+    static const double dblRK_Rational_29443841_614563906 = 29443841.0 / 614563906.0;
+    const REAL_CUDA_ARRAY RK_Rational_29443841_614563906 = ConstCUDA(dblRK_Rational_29443841_614563906);
+
+    static const double dblRK_Rational_77736538_692538347 = 77736538.0 / 692538347.0;
+    const REAL_CUDA_ARRAY RK_Rational_77736538_692538347 = ConstCUDA(dblRK_Rational_77736538_692538347);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_23124283_1800000000, MulCUDA(k6_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_29443841_614563906, MulCUDA(k1_gfsL, dt),
+                                        FusedMulAddCUDA(RK_Rational_77736538_692538347, MulCUDA(k4_gfsL, dt),
+                                                        NegFusedMulAddCUDA(RK_Rational_28693883_1125000000, MulCUDA(k5_gfsL, dt), y_n_gfsL))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_6_gpu
+
+/**
+ * Runge-Kutta function for substep 6.
+ */
+static void rk_substep_6__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k4_gfs, REAL *restrict k5_gfs,
+                                   REAL *restrict k6_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_6_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs, next_y_input_gfs,
+                                                                                  dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_6_gpu failure");
+} // END FUNCTION rk_substep_6__launcher
+
+/**
+ * GPU Kernel: rk_substep_7_gpu.
+ * GPU Kernel to compute RK substep 7.
+ */
+__global__ static void rk_substep_7_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k4_gfs, REAL *restrict k5_gfs,
+                                        REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL k7_gfsL = k7_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_16016141_946692911 = 16016141.0 / 946692911.0;
+    const REAL_CUDA_ARRAY RK_Rational_16016141_946692911 = ConstCUDA(dblRK_Rational_16016141_946692911);
+
+    static const double dblRK_Rational_180193667_1043307555 = 180193667.0 / 1043307555.0;
+    const REAL_CUDA_ARRAY RK_Rational_180193667_1043307555 = ConstCUDA(dblRK_Rational_180193667_1043307555);
+
+    static const double dblRK_Rational_22789713_633445777 = 22789713.0 / 633445777.0;
+    const REAL_CUDA_ARRAY RK_Rational_22789713_633445777 = ConstCUDA(dblRK_Rational_22789713_633445777);
+
+    static const double dblRK_Rational_545815736_2771057229 = 545815736.0 / 2771057229.0;
+    const REAL_CUDA_ARRAY RK_Rational_545815736_2771057229 = ConstCUDA(dblRK_Rational_545815736_2771057229);
+
+    static const double dblRK_Rational_61564180_158732637 = 61564180.0 / 158732637.0;
+    const REAL_CUDA_ARRAY RK_Rational_61564180_158732637 = ConstCUDA(dblRK_Rational_61564180_158732637);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        RK_Rational_545815736_2771057229, MulCUDA(k6_gfsL, dt),
+        FusedMulAddCUDA(RK_Rational_16016141_946692911, MulCUDA(k1_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_22789713_633445777, MulCUDA(k5_gfsL, dt),
+                                        FusedMulAddCUDA(RK_Rational_61564180_158732637, MulCUDA(k4_gfsL, dt),
+                                                        NegFusedMulAddCUDA(RK_Rational_180193667_1043307555, MulCUDA(k7_gfsL, dt), y_n_gfsL)))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_7_gpu
+
+/**
+ * Runge-Kutta function for substep 7.
+ */
+static void rk_substep_7__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k4_gfs, REAL *restrict k5_gfs,
+                                   REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_7_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, y_n_gfs,
+                                                                                  next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_7_gpu failure");
+} // END FUNCTION rk_substep_7__launcher
+
+/**
+ * GPU Kernel: rk_substep_8_gpu.
+ * GPU Kernel to compute RK substep 8.
+ */
+__global__ static void rk_substep_8_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k4_gfs, REAL *restrict k5_gfs,
+                                        REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict k8_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL k7_gfsL = k7_gfs[i];
+    const REAL k8_gfsL = k8_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_100302831_723423059 = 100302831.0 / 723423059.0;
+    const REAL_CUDA_ARRAY RK_Rational_100302831_723423059 = ConstCUDA(dblRK_Rational_100302831_723423059);
+
+    static const double dblRK_Rational_39632708_573591083 = 39632708.0 / 573591083.0;
+    const REAL_CUDA_ARRAY RK_Rational_39632708_573591083 = ConstCUDA(dblRK_Rational_39632708_573591083);
+
+    static const double dblRK_Rational_421739975_2616292301 = 421739975.0 / 2616292301.0;
+    const REAL_CUDA_ARRAY RK_Rational_421739975_2616292301 = ConstCUDA(dblRK_Rational_421739975_2616292301);
+
+    static const double dblRK_Rational_433636366_683701615 = 433636366.0 / 683701615.0;
+    const REAL_CUDA_ARRAY RK_Rational_433636366_683701615 = ConstCUDA(dblRK_Rational_433636366_683701615);
+
+    static const double dblRK_Rational_790204164_839813087 = 790204164.0 / 839813087.0;
+    const REAL_CUDA_ARRAY RK_Rational_790204164_839813087 = ConstCUDA(dblRK_Rational_790204164_839813087);
+
+    static const double dblRK_Rational_800635310_3783071287 = 800635310.0 / 3783071287.0;
+    const REAL_CUDA_ARRAY RK_Rational_800635310_3783071287 = ConstCUDA(dblRK_Rational_800635310_3783071287);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_790204164_839813087, MulCUDA(k7_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_800635310_3783071287, MulCUDA(k8_gfsL, dt),
+                                        FusedMulAddCUDA(RK_Rational_100302831_723423059, MulCUDA(k6_gfsL, dt),
+                                                        FusedMulAddCUDA(RK_Rational_39632708_573591083, MulCUDA(k1_gfsL, dt),
+                                                                        NegFusedMulAddCUDA(RK_Rational_433636366_683701615, MulCUDA(k4_gfsL, dt),
+                                                                                           NegFusedMulAddCUDA(RK_Rational_421739975_2616292301,
+                                                                                                              MulCUDA(k5_gfsL, dt), y_n_gfsL))))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_8_gpu
+
+/**
+ * Runge-Kutta function for substep 8.
+ */
+static void rk_substep_8__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k4_gfs, REAL *restrict k5_gfs,
+                                   REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict k8_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_8_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, k8_gfs, y_n_gfs,
+                                                                                  next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_8_gpu failure");
+} // END FUNCTION rk_substep_8__launcher
+
+/**
+ * GPU Kernel: rk_substep_9_gpu.
+ * GPU Kernel to compute RK substep 9.
+ */
+__global__ static void rk_substep_9_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k4_gfs, REAL *restrict k5_gfs,
+                                        REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict k8_gfs, REAL *restrict k9_gfs,
+                                        REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL k7_gfsL = k7_gfs[i];
+    const REAL k8_gfsL = k8_gfs[i];
+    const REAL k9_gfsL = k9_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_123872331_1001029789 = 123872331.0 / 1001029789.0;
+    const REAL_CUDA_ARRAY RK_Rational_123872331_1001029789 = ConstCUDA(dblRK_Rational_123872331_1001029789);
+
+    static const double dblRK_Rational_12992083_490766935 = 12992083.0 / 490766935.0;
+    const REAL_CUDA_ARRAY RK_Rational_12992083_490766935 = ConstCUDA(dblRK_Rational_12992083_490766935);
+
+    static const double dblRK_Rational_246121993_1340847787 = 246121993.0 / 1340847787.0;
+    const REAL_CUDA_ARRAY RK_Rational_246121993_1340847787 = ConstCUDA(dblRK_Rational_246121993_1340847787);
+
+    static const double dblRK_Rational_309121744_1061227803 = 309121744.0 / 1061227803.0;
+    const REAL_CUDA_ARRAY RK_Rational_309121744_1061227803 = ConstCUDA(dblRK_Rational_309121744_1061227803);
+
+    static const double dblRK_Rational_37695042795_15268766246 = 37695042795.0 / 15268766246.0;
+    const REAL_CUDA_ARRAY RK_Rational_37695042795_15268766246 = ConstCUDA(dblRK_Rational_37695042795_15268766246);
+
+    static const double dblRK_Rational_393006217_1396673457 = 393006217.0 / 1396673457.0;
+    const REAL_CUDA_ARRAY RK_Rational_393006217_1396673457 = ConstCUDA(dblRK_Rational_393006217_1396673457);
+
+    static const double dblRK_Rational_6005943493_2108947869 = 6005943493.0 / 2108947869.0;
+    const REAL_CUDA_ARRAY RK_Rational_6005943493_2108947869 = ConstCUDA(dblRK_Rational_6005943493_2108947869);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = NegFusedMulAddCUDA(
+        RK_Rational_309121744_1061227803, MulCUDA(k5_gfsL, dt),
+        FusedMulAddCUDA(RK_Rational_393006217_1396673457, MulCUDA(k8_gfsL, dt),
+                        FusedMulAddCUDA(RK_Rational_6005943493_2108947869, MulCUDA(k7_gfsL, dt),
+                                        FusedMulAddCUDA(RK_Rational_123872331_1001029789, MulCUDA(k9_gfsL, dt),
+                                                        FusedMulAddCUDA(RK_Rational_246121993_1340847787, MulCUDA(k1_gfsL, dt),
+                                                                        NegFusedMulAddCUDA(RK_Rational_37695042795_15268766246, MulCUDA(k4_gfsL, dt),
+                                                                                           NegFusedMulAddCUDA(RK_Rational_12992083_490766935,
+                                                                                                              MulCUDA(k6_gfsL, dt), y_n_gfsL)))))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_9_gpu
+
+/**
+ * Runge-Kutta function for substep 9.
+ */
+static void rk_substep_9__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k4_gfs, REAL *restrict k5_gfs,
+                                   REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict k8_gfs, REAL *restrict k9_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_9_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, k8_gfs, k9_gfs,
+                                                                                  y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_9_gpu failure");
+} // END FUNCTION rk_substep_9__launcher
+
+/**
+ * GPU Kernel: rk_substep_10_gpu.
+ * GPU Kernel to compute RK substep 10.
+ */
+__global__ static void rk_substep_10_gpu(const size_t streamid, REAL *restrict k10_gfs, REAL *restrict k1_gfs, REAL *restrict k4_gfs,
+                                         REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict k8_gfs,
+                                         REAL *restrict k9_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k10_gfsL = k10_gfs[i];
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL k7_gfsL = k7_gfs[i];
+    const REAL k8_gfsL = k8_gfs[i];
+    const REAL k9_gfsL = k9_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_1028468189_846180014 = 1028468189.0 / 846180014.0;
+    const REAL_CUDA_ARRAY RK_Rational_1028468189_846180014 = ConstCUDA(dblRK_Rational_1028468189_846180014);
+
+    static const double dblRK_Rational_10304129995_1701304382 = 10304129995.0 / 1701304382.0;
+    const REAL_CUDA_ARRAY RK_Rational_10304129995_1701304382 = ConstCUDA(dblRK_Rational_10304129995_1701304382);
+
+    static const double dblRK_Rational_1311729495_1432422823 = 1311729495.0 / 1432422823.0;
+    const REAL_CUDA_ARRAY RK_Rational_1311729495_1432422823 = ConstCUDA(dblRK_Rational_1311729495_1432422823);
+
+    static const double dblRK_Rational_15336726248_1032824649 = 15336726248.0 / 1032824649.0;
+    const REAL_CUDA_ARRAY RK_Rational_15336726248_1032824649 = ConstCUDA(dblRK_Rational_15336726248_1032824649);
+
+    static const double dblRK_Rational_3065993473_597172653 = 3065993473.0 / 597172653.0;
+    const REAL_CUDA_ARRAY RK_Rational_3065993473_597172653 = ConstCUDA(dblRK_Rational_3065993473_597172653);
+
+    static const double dblRK_Rational_45442868181_3398467696 = 45442868181.0 / 3398467696.0;
+    const REAL_CUDA_ARRAY RK_Rational_45442868181_3398467696 = ConstCUDA(dblRK_Rational_45442868181_3398467696);
+
+    static const double dblRK_Rational_48777925059_3047939560 = 48777925059.0 / 3047939560.0;
+    const REAL_CUDA_ARRAY RK_Rational_48777925059_3047939560 = ConstCUDA(dblRK_Rational_48777925059_3047939560);
+
+    static const double dblRK_Rational_8478235783_508512852 = 8478235783.0 / 508512852.0;
+    const REAL_CUDA_ARRAY RK_Rational_8478235783_508512852 = ConstCUDA(dblRK_Rational_8478235783_508512852);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = NegFusedMulAddCUDA(
+        RK_Rational_10304129995_1701304382, MulCUDA(k6_gfsL, dt),
+        NegFusedMulAddCUDA(
+            RK_Rational_45442868181_3398467696, MulCUDA(k9_gfsL, dt),
+            FusedMulAddCUDA(
+                RK_Rational_3065993473_597172653, MulCUDA(k10_gfsL, dt),
+                FusedMulAddCUDA(RK_Rational_8478235783_508512852, MulCUDA(k4_gfsL, dt),
+                                FusedMulAddCUDA(RK_Rational_1311729495_1432422823, MulCUDA(k5_gfsL, dt),
+                                                FusedMulAddCUDA(RK_Rational_15336726248_1032824649, MulCUDA(k8_gfsL, dt),
+                                                                NegFusedMulAddCUDA(RK_Rational_48777925059_3047939560, MulCUDA(k7_gfsL, dt),
+                                                                                   NegFusedMulAddCUDA(RK_Rational_1028468189_846180014,
+                                                                                                      MulCUDA(k1_gfsL, dt), y_n_gfsL))))))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_10_gpu
+
+/**
+ * Runge-Kutta function for substep 10.
+ */
+static void rk_substep_10__launcher(params_struct *restrict params, REAL *restrict k10_gfs, REAL *restrict k1_gfs, REAL *restrict k4_gfs,
+                                    REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict k8_gfs, REAL *restrict k9_gfs,
+                                    REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_10_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k10_gfs, k1_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, k8_gfs,
+                                                                                   k9_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_10_gpu failure");
+} // END FUNCTION rk_substep_10__launcher
+
+/**
+ * GPU Kernel: rk_substep_11_gpu.
+ * GPU Kernel to compute RK substep 11.
+ */
+__global__ static void rk_substep_11_gpu(const size_t streamid, REAL *restrict k10_gfs, REAL *restrict k11_gfs, REAL *restrict k1_gfs,
+                                         REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict k7_gfs,
+                                         REAL *restrict k8_gfs, REAL *restrict k9_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                         const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k10_gfsL = k10_gfs[i];
+    const REAL k11_gfsL = k11_gfs[i];
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL k7_gfsL = k7_gfs[i];
+    const REAL k8_gfsL = k8_gfs[i];
+    const REAL k9_gfsL = k9_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_185892177_718116043 = 185892177.0 / 718116043.0;
+    const REAL_CUDA_ARRAY RK_Rational_185892177_718116043 = ConstCUDA(dblRK_Rational_185892177_718116043);
+
+    static const double dblRK_Rational_3185094517_667107341 = 3185094517.0 / 667107341.0;
+    const REAL_CUDA_ARRAY RK_Rational_3185094517_667107341 = ConstCUDA(dblRK_Rational_3185094517_667107341);
+
+    static const double dblRK_Rational_3962137247_1805957418 = 3962137247.0 / 1805957418.0;
+    const REAL_CUDA_ARRAY RK_Rational_3962137247_1805957418 = ConstCUDA(dblRK_Rational_3962137247_1805957418);
+
+    static const double dblRK_Rational_4093664535_808688257 = 4093664535.0 / 808688257.0;
+    const REAL_CUDA_ARRAY RK_Rational_4093664535_808688257 = ConstCUDA(dblRK_Rational_4093664535_808688257);
+
+    static const double dblRK_Rational_477755414_1098053517 = 477755414.0 / 1098053517.0;
+    const REAL_CUDA_ARRAY RK_Rational_477755414_1098053517 = ConstCUDA(dblRK_Rational_477755414_1098053517);
+
+    static const double dblRK_Rational_5232866602_850066563 = 5232866602.0 / 850066563.0;
+    const REAL_CUDA_ARRAY RK_Rational_5232866602_850066563 = ConstCUDA(dblRK_Rational_5232866602_850066563);
+
+    static const double dblRK_Rational_5731566787_1027545527 = 5731566787.0 / 1027545527.0;
+    const REAL_CUDA_ARRAY RK_Rational_5731566787_1027545527 = ConstCUDA(dblRK_Rational_5731566787_1027545527);
+
+    static const double dblRK_Rational_65686358_487910083 = 65686358.0 / 487910083.0;
+    const REAL_CUDA_ARRAY RK_Rational_65686358_487910083 = ConstCUDA(dblRK_Rational_65686358_487910083);
+
+    static const double dblRK_Rational_703635378_230739211 = 703635378.0 / 230739211.0;
+    const REAL_CUDA_ARRAY RK_Rational_703635378_230739211 = ConstCUDA(dblRK_Rational_703635378_230739211);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = NegFusedMulAddCUDA(
+        RK_Rational_477755414_1098053517, MulCUDA(k5_gfsL, dt),
+        FusedMulAddCUDA(
+            RK_Rational_65686358_487910083, MulCUDA(k11_gfsL, dt),
+            NegFusedMulAddCUDA(
+                RK_Rational_4093664535_808688257, MulCUDA(k9_gfsL, dt),
+                FusedMulAddCUDA(
+                    RK_Rational_5232866602_850066563, MulCUDA(k8_gfsL, dt),
+                    FusedMulAddCUDA(RK_Rational_5731566787_1027545527, MulCUDA(k7_gfsL, dt),
+                                    FusedMulAddCUDA(RK_Rational_185892177_718116043, MulCUDA(k1_gfsL, dt),
+                                                    FusedMulAddCUDA(RK_Rational_3962137247_1805957418, MulCUDA(k10_gfsL, dt),
+                                                                    NegFusedMulAddCUDA(RK_Rational_703635378_230739211, MulCUDA(k6_gfsL, dt),
+                                                                                       NegFusedMulAddCUDA(RK_Rational_3185094517_667107341,
+                                                                                                          MulCUDA(k4_gfsL, dt), y_n_gfsL)))))))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_11_gpu
+
+/**
+ * Runge-Kutta function for substep 11.
+ */
+static void rk_substep_11__launcher(params_struct *restrict params, REAL *restrict k10_gfs, REAL *restrict k11_gfs, REAL *restrict k1_gfs,
+                                    REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict k8_gfs,
+                                    REAL *restrict k9_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_11_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k10_gfs, k11_gfs, k1_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs,
+                                                                                   k8_gfs, k9_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_11_gpu failure");
+} // END FUNCTION rk_substep_11__launcher
+
+/**
+ * GPU Kernel: rk_substep_12_gpu.
+ * GPU Kernel to compute RK substep 12.
+ */
+__global__ static void rk_substep_12_gpu(const size_t streamid, REAL *restrict k10_gfs, REAL *restrict k11_gfs, REAL *restrict k1_gfs,
+                                         REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict k7_gfs,
+                                         REAL *restrict k8_gfs, REAL *restrict k9_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                         const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k10_gfsL = k10_gfs[i];
+    const REAL k11_gfsL = k11_gfs[i];
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL k7_gfsL = k7_gfs[i];
+    const REAL k8_gfsL = k8_gfs[i];
+    const REAL k9_gfsL = k9_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_11173962825_925320556 = 11173962825.0 / 925320556.0;
+    const REAL_CUDA_ARRAY RK_Rational_11173962825_925320556 = ConstCUDA(dblRK_Rational_11173962825_925320556);
+
+    static const double dblRK_Rational_13158990841_6184727034 = 13158990841.0 / 6184727034.0;
+    const REAL_CUDA_ARRAY RK_Rational_13158990841_6184727034 = ConstCUDA(dblRK_Rational_13158990841_6184727034);
+
+    static const double dblRK_Rational_160528059_685178525 = 160528059.0 / 685178525.0;
+    const REAL_CUDA_ARRAY RK_Rational_160528059_685178525 = ConstCUDA(dblRK_Rational_160528059_685178525);
+
+    static const double dblRK_Rational_248638103_1413531060 = 248638103.0 / 1413531060.0;
+    const REAL_CUDA_ARRAY RK_Rational_248638103_1413531060 = ConstCUDA(dblRK_Rational_248638103_1413531060);
+
+    static const double dblRK_Rational_3936647629_1978049680 = 3936647629.0 / 1978049680.0;
+    const REAL_CUDA_ARRAY RK_Rational_3936647629_1978049680 = ConstCUDA(dblRK_Rational_3936647629_1978049680);
+
+    static const double dblRK_Rational_403863854_491063109 = 403863854.0 / 491063109.0;
+    const REAL_CUDA_ARRAY RK_Rational_403863854_491063109 = ConstCUDA(dblRK_Rational_403863854_491063109);
+
+    static const double dblRK_Rational_411421997_543043805 = 411421997.0 / 543043805.0;
+    const REAL_CUDA_ARRAY RK_Rational_411421997_543043805 = ConstCUDA(dblRK_Rational_411421997_543043805);
+
+    static const double dblRK_Rational_5068492393_434740067 = 5068492393.0 / 434740067.0;
+    const REAL_CUDA_ARRAY RK_Rational_5068492393_434740067 = ConstCUDA(dblRK_Rational_5068492393_434740067);
+
+    static const double dblRK_Rational_652783627_914296604 = 652783627.0 / 914296604.0;
+    const REAL_CUDA_ARRAY RK_Rational_652783627_914296604 = ConstCUDA(dblRK_Rational_652783627_914296604);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = NegFusedMulAddCUDA(
+        RK_Rational_411421997_543043805, MulCUDA(k5_gfsL, dt),
+        FusedMulAddCUDA(
+            RK_Rational_652783627_914296604, MulCUDA(k6_gfsL, dt),
+            NegFusedMulAddCUDA(
+                RK_Rational_160528059_685178525, MulCUDA(k10_gfsL, dt),
+                FusedMulAddCUDA(
+                    RK_Rational_3936647629_1978049680, MulCUDA(k9_gfsL, dt),
+                    FusedMulAddCUDA(RK_Rational_403863854_491063109, MulCUDA(k1_gfsL, dt),
+                                    FusedMulAddCUDA(RK_Rational_11173962825_925320556, MulCUDA(k7_gfsL, dt),
+                                                    FusedMulAddCUDA(RK_Rational_248638103_1413531060, MulCUDA(k11_gfsL, dt),
+                                                                    NegFusedMulAddCUDA(RK_Rational_5068492393_434740067, MulCUDA(k4_gfsL, dt),
+                                                                                       NegFusedMulAddCUDA(RK_Rational_13158990841_6184727034,
+                                                                                                          MulCUDA(k8_gfsL, dt), y_n_gfsL)))))))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_12_gpu
+
+/**
+ * Runge-Kutta function for substep 12.
+ */
+static void rk_substep_12__launcher(params_struct *restrict params, REAL *restrict k10_gfs, REAL *restrict k11_gfs, REAL *restrict k1_gfs,
+                                    REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict k8_gfs,
+                                    REAL *restrict k9_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_12_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k10_gfs, k11_gfs, k1_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs,
+                                                                                   k8_gfs, k9_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_12_gpu failure");
+} // END FUNCTION rk_substep_12__launcher
+
+/**
+ * GPU Kernel: rk_substep_13_gpu.
+ * GPU Kernel to compute RK substep 13.
+ */
+__global__ static void rk_substep_13_gpu(const size_t streamid, REAL *restrict k10_gfs, REAL *restrict k11_gfs, REAL *restrict k12_gfs,
+                                         REAL *restrict k13_gfs, REAL *restrict k1_gfs, REAL *restrict k6_gfs, REAL *restrict k7_gfs,
+                                         REAL *restrict k8_gfs, REAL *restrict k9_gfs, REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k10_gfsL = k10_gfs[i];
+    const REAL k11_gfsL = k11_gfs[i];
+    const REAL k12_gfsL = k12_gfs[i];
+    const REAL k13_gfsL = k13_gfs[i];
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL k7_gfsL = k7_gfs[i];
+    const REAL k8_gfsL = k8_gfs[i];
+    const REAL k9_gfsL = k9_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_1041891430_1371343529 = 1041891430.0 / 1371343529.0;
+    const REAL_CUDA_ARRAY RK_Rational_1041891430_1371343529 = ConstCUDA(dblRK_Rational_1041891430_1371343529);
+
+    static const double dblRK_Rational_118820643_751138087 = 118820643.0 / 751138087.0;
+    const REAL_CUDA_ARRAY RK_Rational_118820643_751138087 = ConstCUDA(dblRK_Rational_118820643_751138087);
+
+    static const double dblRK_Rational_14005451_335480064 = 14005451.0 / 335480064.0;
+    const REAL_CUDA_ARRAY RK_Rational_14005451_335480064 = ConstCUDA(dblRK_Rational_14005451_335480064);
+
+    static const double dblRK_Rational_181606767_758867731 = 181606767.0 / 758867731.0;
+    const REAL_CUDA_ARRAY RK_Rational_181606767_758867731 = ConstCUDA(dblRK_Rational_181606767_758867731);
+
+    static const double dblRK_Rational_1_4 = 1.0 / 4.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_4 = ConstCUDA(dblRK_Rational_1_4);
+
+    static const double dblRK_Rational_528747749_2220607170 = 528747749.0 / 2220607170.0;
+    const REAL_CUDA_ARRAY RK_Rational_528747749_2220607170 = ConstCUDA(dblRK_Rational_528747749_2220607170);
+
+    static const double dblRK_Rational_561292985_797845732 = 561292985.0 / 797845732.0;
+    const REAL_CUDA_ARRAY RK_Rational_561292985_797845732 = ConstCUDA(dblRK_Rational_561292985_797845732);
+
+    static const double dblRK_Rational_59238493_1068277825 = 59238493.0 / 1068277825.0;
+    const REAL_CUDA_ARRAY RK_Rational_59238493_1068277825 = ConstCUDA(dblRK_Rational_59238493_1068277825);
+
+    static const double dblRK_Rational_760417239_1151165299 = 760417239.0 / 1151165299.0;
+    const REAL_CUDA_ARRAY RK_Rational_760417239_1151165299 = ConstCUDA(dblRK_Rational_760417239_1151165299);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = NegFusedMulAddCUDA(
+        RK_Rational_528747749_2220607170, MulCUDA(k12_gfsL, dt),
+        FusedMulAddCUDA(
+            RK_Rational_561292985_797845732, MulCUDA(k8_gfsL, dt),
+            FusedMulAddCUDA(
+                RK_Rational_760417239_1151165299, MulCUDA(k10_gfsL, dt),
+                FusedMulAddCUDA(
+                    RK_Rational_181606767_758867731, MulCUDA(k7_gfsL, dt),
+                    FusedMulAddCUDA(RK_Rational_1_4, MulCUDA(k13_gfsL, dt),
+                                    FusedMulAddCUDA(RK_Rational_118820643_751138087, MulCUDA(k11_gfsL, dt),
+                                                    FusedMulAddCUDA(RK_Rational_14005451_335480064, MulCUDA(k1_gfsL, dt),
+                                                                    NegFusedMulAddCUDA(RK_Rational_59238493_1068277825, MulCUDA(k6_gfsL, dt),
+                                                                                       NegFusedMulAddCUDA(RK_Rational_1041891430_1371343529,
+                                                                                                          MulCUDA(k9_gfsL, dt), y_n_gfsL)))))))));
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_13_gpu
+
+/**
+ * Runge-Kutta function for substep 13.
+ */
+static void rk_substep_13__launcher(params_struct *restrict params, REAL *restrict k10_gfs, REAL *restrict k11_gfs, REAL *restrict k12_gfs,
+                                    REAL *restrict k13_gfs, REAL *restrict k1_gfs, REAL *restrict k6_gfs, REAL *restrict k7_gfs,
+                                    REAL *restrict k8_gfs, REAL *restrict k9_gfs, REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_13_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k10_gfs, k11_gfs, k12_gfs, k13_gfs, k1_gfs, k6_gfs,
+                                                                                   k7_gfs, k8_gfs, k9_gfs, y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_13_gpu failure");
+} // END FUNCTION rk_substep_13__launcher
+
+/**
+ * Method of Lines (MoL) for "DP8" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ DP8 }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+  // -={ START k1 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict k9_gfs = griddata[grid].gridfuncs.k9_gfs;
+    MAYBE_UNUSED REAL *restrict k10_gfs = griddata[grid].gridfuncs.k10_gfs;
+    MAYBE_UNUSED REAL *restrict k11_gfs = griddata[grid].gridfuncs.k11_gfs;
+    MAYBE_UNUSED REAL *restrict k12_gfs = griddata[grid].gridfuncs.k12_gfs;
+    MAYBE_UNUSED REAL *restrict k13_gfs = griddata[grid].gridfuncs.k13_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k1_gfs);
+    rk_substep_1__launcher(params, k1_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 5.55555555555555525e-02 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict k9_gfs = griddata[grid].gridfuncs.k9_gfs;
+    MAYBE_UNUSED REAL *restrict k10_gfs = griddata[grid].gridfuncs.k10_gfs;
+    MAYBE_UNUSED REAL *restrict k11_gfs = griddata[grid].gridfuncs.k11_gfs;
+    MAYBE_UNUSED REAL *restrict k12_gfs = griddata[grid].gridfuncs.k12_gfs;
+    MAYBE_UNUSED REAL *restrict k13_gfs = griddata[grid].gridfuncs.k13_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k2_gfs);
+    rk_substep_2__launcher(params, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // -={ START k3 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 8.33333333333333287e-02 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict k9_gfs = griddata[grid].gridfuncs.k9_gfs;
+    MAYBE_UNUSED REAL *restrict k10_gfs = griddata[grid].gridfuncs.k10_gfs;
+    MAYBE_UNUSED REAL *restrict k11_gfs = griddata[grid].gridfuncs.k11_gfs;
+    MAYBE_UNUSED REAL *restrict k12_gfs = griddata[grid].gridfuncs.k12_gfs;
+    MAYBE_UNUSED REAL *restrict k13_gfs = griddata[grid].gridfuncs.k13_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k3_gfs);
+    rk_substep_3__launcher(params, k1_gfs, k3_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k3 substep }=-
+
+  // -={ START k4 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.25000000000000000e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict k9_gfs = griddata[grid].gridfuncs.k9_gfs;
+    MAYBE_UNUSED REAL *restrict k10_gfs = griddata[grid].gridfuncs.k10_gfs;
+    MAYBE_UNUSED REAL *restrict k11_gfs = griddata[grid].gridfuncs.k11_gfs;
+    MAYBE_UNUSED REAL *restrict k12_gfs = griddata[grid].gridfuncs.k12_gfs;
+    MAYBE_UNUSED REAL *restrict k13_gfs = griddata[grid].gridfuncs.k13_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k4_gfs);
+    rk_substep_4__launcher(params, k1_gfs, k3_gfs, k4_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k4 substep }=-
+
+  // -={ START k5 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 3.12500000000000000e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict k9_gfs = griddata[grid].gridfuncs.k9_gfs;
+    MAYBE_UNUSED REAL *restrict k10_gfs = griddata[grid].gridfuncs.k10_gfs;
+    MAYBE_UNUSED REAL *restrict k11_gfs = griddata[grid].gridfuncs.k11_gfs;
+    MAYBE_UNUSED REAL *restrict k12_gfs = griddata[grid].gridfuncs.k12_gfs;
+    MAYBE_UNUSED REAL *restrict k13_gfs = griddata[grid].gridfuncs.k13_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k5_gfs);
+    rk_substep_5__launcher(params, k1_gfs, k4_gfs, k5_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k5 substep }=-
+
+  // -={ START k6 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 3.75000000000000000e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict k9_gfs = griddata[grid].gridfuncs.k9_gfs;
+    MAYBE_UNUSED REAL *restrict k10_gfs = griddata[grid].gridfuncs.k10_gfs;
+    MAYBE_UNUSED REAL *restrict k11_gfs = griddata[grid].gridfuncs.k11_gfs;
+    MAYBE_UNUSED REAL *restrict k12_gfs = griddata[grid].gridfuncs.k12_gfs;
+    MAYBE_UNUSED REAL *restrict k13_gfs = griddata[grid].gridfuncs.k13_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k6_gfs);
+    rk_substep_6__launcher(params, k1_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k6 substep }=-
+
+  // -={ START k7 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.47499999999999992e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict k9_gfs = griddata[grid].gridfuncs.k9_gfs;
+    MAYBE_UNUSED REAL *restrict k10_gfs = griddata[grid].gridfuncs.k10_gfs;
+    MAYBE_UNUSED REAL *restrict k11_gfs = griddata[grid].gridfuncs.k11_gfs;
+    MAYBE_UNUSED REAL *restrict k12_gfs = griddata[grid].gridfuncs.k12_gfs;
+    MAYBE_UNUSED REAL *restrict k13_gfs = griddata[grid].gridfuncs.k13_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k7_gfs);
+    rk_substep_7__launcher(params, k1_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k7 substep }=-
+
+  // -={ START k8 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 4.65000000000000024e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict k9_gfs = griddata[grid].gridfuncs.k9_gfs;
+    MAYBE_UNUSED REAL *restrict k10_gfs = griddata[grid].gridfuncs.k10_gfs;
+    MAYBE_UNUSED REAL *restrict k11_gfs = griddata[grid].gridfuncs.k11_gfs;
+    MAYBE_UNUSED REAL *restrict k12_gfs = griddata[grid].gridfuncs.k12_gfs;
+    MAYBE_UNUSED REAL *restrict k13_gfs = griddata[grid].gridfuncs.k13_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k8_gfs);
+    rk_substep_8__launcher(params, k1_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, k8_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k8 substep }=-
+
+  // -={ START k9 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 5.64865451382259520e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict k9_gfs = griddata[grid].gridfuncs.k9_gfs;
+    MAYBE_UNUSED REAL *restrict k10_gfs = griddata[grid].gridfuncs.k10_gfs;
+    MAYBE_UNUSED REAL *restrict k11_gfs = griddata[grid].gridfuncs.k11_gfs;
+    MAYBE_UNUSED REAL *restrict k12_gfs = griddata[grid].gridfuncs.k12_gfs;
+    MAYBE_UNUSED REAL *restrict k13_gfs = griddata[grid].gridfuncs.k13_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k9_gfs);
+    rk_substep_9__launcher(params, k1_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, k8_gfs, k9_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k9 substep }=-
+
+  // -={ START k10 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 6.50000000000000022e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict k9_gfs = griddata[grid].gridfuncs.k9_gfs;
+    MAYBE_UNUSED REAL *restrict k10_gfs = griddata[grid].gridfuncs.k10_gfs;
+    MAYBE_UNUSED REAL *restrict k11_gfs = griddata[grid].gridfuncs.k11_gfs;
+    MAYBE_UNUSED REAL *restrict k12_gfs = griddata[grid].gridfuncs.k12_gfs;
+    MAYBE_UNUSED REAL *restrict k13_gfs = griddata[grid].gridfuncs.k13_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k10_gfs);
+    rk_substep_10__launcher(params, k10_gfs, k1_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, k8_gfs, k9_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k10 substep }=-
+
+  // -={ START k11 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 9.24656277640504398e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict k9_gfs = griddata[grid].gridfuncs.k9_gfs;
+    MAYBE_UNUSED REAL *restrict k10_gfs = griddata[grid].gridfuncs.k10_gfs;
+    MAYBE_UNUSED REAL *restrict k11_gfs = griddata[grid].gridfuncs.k11_gfs;
+    MAYBE_UNUSED REAL *restrict k12_gfs = griddata[grid].gridfuncs.k12_gfs;
+    MAYBE_UNUSED REAL *restrict k13_gfs = griddata[grid].gridfuncs.k13_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k11_gfs);
+    rk_substep_11__launcher(params, k10_gfs, k11_gfs, k1_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, k8_gfs, k9_gfs, y_n_gfs, next_y_input_gfs,
+                            commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k11 substep }=-
+
+  // -={ START k12 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict k9_gfs = griddata[grid].gridfuncs.k9_gfs;
+    MAYBE_UNUSED REAL *restrict k10_gfs = griddata[grid].gridfuncs.k10_gfs;
+    MAYBE_UNUSED REAL *restrict k11_gfs = griddata[grid].gridfuncs.k11_gfs;
+    MAYBE_UNUSED REAL *restrict k12_gfs = griddata[grid].gridfuncs.k12_gfs;
+    MAYBE_UNUSED REAL *restrict k13_gfs = griddata[grid].gridfuncs.k13_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k12_gfs);
+    rk_substep_12__launcher(params, k10_gfs, k11_gfs, k1_gfs, k4_gfs, k5_gfs, k6_gfs, k7_gfs, k8_gfs, k9_gfs, y_n_gfs, next_y_input_gfs,
+                            commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k12 substep }=-
+
+  // -={ START k13 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict k8_gfs = griddata[grid].gridfuncs.k8_gfs;
+    MAYBE_UNUSED REAL *restrict k9_gfs = griddata[grid].gridfuncs.k9_gfs;
+    MAYBE_UNUSED REAL *restrict k10_gfs = griddata[grid].gridfuncs.k10_gfs;
+    MAYBE_UNUSED REAL *restrict k11_gfs = griddata[grid].gridfuncs.k11_gfs;
+    MAYBE_UNUSED REAL *restrict k12_gfs = griddata[grid].gridfuncs.k12_gfs;
+    MAYBE_UNUSED REAL *restrict k13_gfs = griddata[grid].gridfuncs.k13_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k13_gfs);
+    rk_substep_13__launcher(params, k10_gfs, k11_gfs, k12_gfs, k13_gfs, k1_gfs, k6_gfs, k7_gfs, k8_gfs, k9_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k13 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__Euler.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__Euler.cu
@@ -1,0 +1,80 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_None_gpu.
+ * GPU Kernel to compute RK substep None.
+ */
+__global__ static void rk_substep_None_gpu(const size_t streamid, REAL *restrict y_n_gfs, REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL y_n_gfsL = y_n_gfs[i];
+    const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(dt, y_nplus1_running_total_gfsL, y_n_gfsL);
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_None_gpu
+
+/**
+ * Runge-Kutta function for substep None.
+ */
+static void rk_substep_None__launcher(params_struct *restrict params, REAL *restrict y_n_gfs, REAL *restrict y_nplus1_running_total_gfs,
+                                      const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_None_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, y_n_gfs, y_nplus1_running_total_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_None_gpu failure");
+} // END FUNCTION rk_substep_None__launcher
+
+/**
+ * Method of Lines (MoL) for "Euler" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ Euler }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+  // ***Euler timestepping only requires one RHS evaluation***// ***Euler timestepping only requires one RHS evaluation***
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, y_nplus1_running_total_gfs);
+    rk_substep_None__launcher(params, y_n_gfs, y_nplus1_running_total_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__L6.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__L6.cu
@@ -1,0 +1,624 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(k1_gfsL, dt, y_n_gfsL);
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_8 = 1.0 / 8.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_8 = ConstCUDA(dblRK_Rational_1_8);
+
+    static const double dblRK_Rational_3_8 = 3.0 / 8.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_8 = ConstCUDA(dblRK_Rational_3_8);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_1_8, MulCUDA(k2_gfsL, dt), FusedMulAddCUDA(RK_Rational_3_8, MulCUDA(k1_gfsL, dt), y_n_gfsL));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * GPU Kernel: rk_substep_3_gpu.
+ * GPU Kernel to compute RK substep 3.
+ */
+__global__ static void rk_substep_3_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_2_27 = 2.0 / 27.0;
+    const REAL_CUDA_ARRAY RK_Rational_2_27 = ConstCUDA(dblRK_Rational_2_27);
+
+    static const double dblRK_Rational_8_27 = 8.0 / 27.0;
+    const REAL_CUDA_ARRAY RK_Rational_8_27 = ConstCUDA(dblRK_Rational_8_27);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_8_27, FusedMulAddCUDA(k1_gfsL, dt, MulCUDA(k3_gfsL, dt)),
+                                                       FusedMulAddCUDA(RK_Rational_2_27, MulCUDA(k2_gfsL, dt), y_n_gfsL));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_3_gpu
+
+/**
+ * Runge-Kutta function for substep 3.
+ */
+static void rk_substep_3__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_3_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_3_gpu failure");
+} // END FUNCTION rk_substep_3__launcher
+
+/**
+ * GPU Kernel: rk_substep_4_gpu.
+ * GPU Kernel to compute RK substep 4.
+ */
+__global__ static void rk_substep_4_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_1_49 = 1.0 / 49.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_49 = ConstCUDA(dblRK_Rational_1_49);
+
+    static const double dblRK_Rational_1_7 = 1.0 / 7.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_7 = ConstCUDA(dblRK_Rational_1_7);
+
+    static const double dblRK_Rational_3_392 = 3.0 / 392.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_392 = ConstCUDA(dblRK_Rational_3_392);
+
+    static const double dblRK_Rational_3_56 = 3.0 / 56.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_56 = ConstCUDA(dblRK_Rational_3_56);
+
+    static const double dblRK_Rational_6_49 = 6.0 / 49.0;
+    const REAL_CUDA_ARRAY RK_Rational_6_49 = ConstCUDA(dblRK_Rational_6_49);
+
+    static const double dblRK_Rational_6_7 = 6.0 / 7.0;
+    const REAL_CUDA_ARRAY RK_Rational_6_7 = ConstCUDA(dblRK_Rational_6_7);
+
+    static const double dblRK_Rational_9_392 = 9.0 / 392.0;
+    const REAL_CUDA_ARRAY RK_Rational_9_392 = ConstCUDA(dblRK_Rational_9_392);
+
+    static const double dblRK_Rational_9_56 = 9.0 / 56.0;
+    const REAL_CUDA_ARRAY RK_Rational_9_56 = ConstCUDA(dblRK_Rational_9_56);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        k2_gfsL, MulCUDA(dt, FusedMulSubCUDA(RK_Rational_1_49, SqrtCUDA(21), RK_Rational_1_7)),
+        FusedMulAddCUDA(
+            k3_gfsL, MulCUDA(dt, NegFusedMulAddCUDA(RK_Rational_6_49, SqrtCUDA(21), RK_Rational_6_7)),
+            FusedMulAddCUDA(k4_gfsL, MulCUDA(dt, FusedMulSubCUDA(RK_Rational_3_392, SqrtCUDA(21), RK_Rational_9_56)),
+                            FusedMulAddCUDA(k1_gfsL, MulCUDA(dt, FusedMulSubCUDA(RK_Rational_9_392, SqrtCUDA(21), RK_Rational_3_56)), y_n_gfsL))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_4_gpu
+
+/**
+ * Runge-Kutta function for substep 4.
+ */
+static void rk_substep_4__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_4_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, y_n_gfs, next_y_input_gfs,
+                                                                                  dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_4_gpu failure");
+} // END FUNCTION rk_substep_4__launcher
+
+/**
+ * GPU Kernel: rk_substep_5_gpu.
+ * GPU Kernel to compute RK substep 5.
+ */
+__global__ static void rk_substep_5_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_1_49 = 1.0 / 49.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_49 = ConstCUDA(dblRK_Rational_1_49);
+
+    static const double dblRK_Rational_1_5 = 1.0 / 5.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_5 = ConstCUDA(dblRK_Rational_1_5);
+
+    static const double dblRK_Rational_1_7 = 1.0 / 7.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_7 = ConstCUDA(dblRK_Rational_1_7);
+
+    static const double dblRK_Rational_33_56 = 33.0 / 56.0;
+    const REAL_CUDA_ARRAY RK_Rational_33_56 = ConstCUDA(dblRK_Rational_33_56);
+
+    static const double dblRK_Rational_363_1960 = 363.0 / 1960.0;
+    const REAL_CUDA_ARRAY RK_Rational_363_1960 = ConstCUDA(dblRK_Rational_363_1960);
+
+    static const double dblRK_Rational_51_392 = 51.0 / 392.0;
+    const REAL_CUDA_ARRAY RK_Rational_51_392 = ConstCUDA(dblRK_Rational_51_392);
+
+    static const double dblRK_Rational_6_5 = 6.0 / 5.0;
+    const REAL_CUDA_ARRAY RK_Rational_6_5 = ConstCUDA(dblRK_Rational_6_5);
+
+    static const double dblRK_Rational_8_49 = 8.0 / 49.0;
+    const REAL_CUDA_ARRAY RK_Rational_8_49 = ConstCUDA(dblRK_Rational_8_49);
+
+    static const double dblRK_Rational_9_280 = 9.0 / 280.0;
+    const REAL_CUDA_ARRAY RK_Rational_9_280 = ConstCUDA(dblRK_Rational_9_280);
+
+    const REAL_CUDA_ARRAY tmp1 = MulCUDA(_NegativeOne_, SqrtCUDA(21));
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        k2_gfsL, MulCUDA(dt, FusedMulSubCUDA(RK_Rational_1_49, tmp1, RK_Rational_1_7)),
+        FusedMulAddCUDA(
+            k4_gfsL, MulCUDA(dt, FusedMulAddCUDA(RK_Rational_363_1960, SqrtCUDA(21), RK_Rational_9_280)),
+            FusedMulAddCUDA(
+                k5_gfsL, MulCUDA(dt, FusedMulAddCUDA(RK_Rational_1_5, SqrtCUDA(21), RK_Rational_6_5)),
+                FusedMulAddCUDA(MulCUDA(RK_Rational_8_49, k3_gfsL), MulCUDA(tmp1, dt),
+                                FusedMulAddCUDA(k1_gfsL, MulCUDA(dt, FusedMulSubCUDA(RK_Rational_51_392, tmp1, RK_Rational_33_56)), y_n_gfsL)))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_5_gpu
+
+/**
+ * Runge-Kutta function for substep 5.
+ */
+static void rk_substep_5__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_5_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, y_n_gfs,
+                                                                                  next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_5_gpu failure");
+} // END FUNCTION rk_substep_5__launcher
+
+/**
+ * GPU Kernel: rk_substep_6_gpu.
+ * GPU Kernel to compute RK substep 6.
+ */
+__global__ static void rk_substep_6_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k4_gfsL = k4_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    static const double dblRK_Rational_10_9 = 10.0 / 9.0;
+    const REAL_CUDA_ARRAY RK_Rational_10_9 = ConstCUDA(dblRK_Rational_10_9);
+
+    static const double dblRK_Rational_11_6 = 11.0 / 6.0;
+    const REAL_CUDA_ARRAY RK_Rational_11_6 = ConstCUDA(dblRK_Rational_11_6);
+
+    static const double dblRK_Rational_14_9 = 14.0 / 9.0;
+    const REAL_CUDA_ARRAY RK_Rational_14_9 = ConstCUDA(dblRK_Rational_14_9);
+
+    static const double dblRK_Rational_21_20 = 21.0 / 20.0;
+    const REAL_CUDA_ARRAY RK_Rational_21_20 = ConstCUDA(dblRK_Rational_21_20);
+
+    static const double dblRK_Rational_2_3 = 2.0 / 3.0;
+    const REAL_CUDA_ARRAY RK_Rational_2_3 = ConstCUDA(dblRK_Rational_2_3);
+
+    static const double dblRK_Rational_343_90 = 343.0 / 90.0;
+    const REAL_CUDA_ARRAY RK_Rational_343_90 = ConstCUDA(dblRK_Rational_343_90);
+
+    static const double dblRK_Rational_49_18 = 49.0 / 18.0;
+    const REAL_CUDA_ARRAY RK_Rational_49_18 = ConstCUDA(dblRK_Rational_49_18);
+
+    static const double dblRK_Rational_7_10 = 7.0 / 10.0;
+    const REAL_CUDA_ARRAY RK_Rational_7_10 = ConstCUDA(dblRK_Rational_7_10);
+
+    static const double dblRK_Rational_7_12 = 7.0 / 12.0;
+    const REAL_CUDA_ARRAY RK_Rational_7_12 = ConstCUDA(dblRK_Rational_7_12);
+
+    static const double dblRK_Rational_7_18 = 7.0 / 18.0;
+    const REAL_CUDA_ARRAY RK_Rational_7_18 = ConstCUDA(dblRK_Rational_7_18);
+
+    const REAL_CUDA_ARRAY tmp1 = MulCUDA(_NegativeOne_, SqrtCUDA(21));
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(
+        k4_gfsL, MulCUDA(dt, FusedMulAddCUDA(RK_Rational_21_20, tmp1, RK_Rational_7_10)),
+        FusedMulAddCUDA(
+            k1_gfsL, MulCUDA(dt, FusedMulAddCUDA(RK_Rational_7_12, SqrtCUDA(21), RK_Rational_11_6)),
+            FusedMulAddCUDA(k3_gfsL, MulCUDA(dt, FusedMulSubCUDA(RK_Rational_14_9, SqrtCUDA(21), RK_Rational_10_9)),
+                            FusedMulAddCUDA(k5_gfsL, MulCUDA(dt, FusedMulSubCUDA(RK_Rational_7_10, tmp1, RK_Rational_343_90)),
+                                            FusedMulAddCUDA(k6_gfsL, MulCUDA(dt, FusedMulAddCUDA(RK_Rational_7_18, tmp1, RK_Rational_49_18)),
+                                                            FusedMulAddCUDA(RK_Rational_2_3, MulCUDA(k2_gfsL, dt), y_n_gfsL))))));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_6_gpu
+
+/**
+ * Runge-Kutta function for substep 6.
+ */
+static void rk_substep_6__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict k4_gfs, REAL *restrict k5_gfs, REAL *restrict k6_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_6_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs,
+                                                                                  next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_6_gpu failure");
+} // END FUNCTION rk_substep_6__launcher
+
+/**
+ * GPU Kernel: rk_substep_7_gpu.
+ * GPU Kernel to compute RK substep 7.
+ */
+__global__ static void rk_substep_7_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k5_gfs,
+                                        REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL k5_gfsL = k5_gfs[i];
+    const REAL k6_gfsL = k6_gfs[i];
+    const REAL k7_gfsL = k7_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_16_45 = 16.0 / 45.0;
+    const REAL_CUDA_ARRAY RK_Rational_16_45 = ConstCUDA(dblRK_Rational_16_45);
+
+    static const double dblRK_Rational_1_20 = 1.0 / 20.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_20 = ConstCUDA(dblRK_Rational_1_20);
+
+    static const double dblRK_Rational_49_180 = 49.0 / 180.0;
+    const REAL_CUDA_ARRAY RK_Rational_49_180 = ConstCUDA(dblRK_Rational_49_180);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_49_180, FusedMulAddCUDA(k5_gfsL, dt, MulCUDA(k6_gfsL, dt)),
+                        FusedMulAddCUDA(RK_Rational_16_45, MulCUDA(k3_gfsL, dt),
+                                        FusedMulAddCUDA(RK_Rational_1_20, FusedMulAddCUDA(k1_gfsL, dt, MulCUDA(k7_gfsL, dt)), y_n_gfsL)));
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_7_gpu
+
+/**
+ * Runge-Kutta function for substep 7.
+ */
+static void rk_substep_7__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k3_gfs, REAL *restrict k5_gfs,
+                                   REAL *restrict k6_gfs, REAL *restrict k7_gfs, REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_7_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k3_gfs, k5_gfs, k6_gfs, k7_gfs, y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_7_gpu failure");
+} // END FUNCTION rk_substep_7__launcher
+
+/**
+ * Method of Lines (MoL) for "L6" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ L6 }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+  // -={ START k1 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k1_gfs);
+    rk_substep_1__launcher(params, k1_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k2_gfs);
+    rk_substep_2__launcher(params, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // -={ START k3 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 5.00000000000000000e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k3_gfs);
+    rk_substep_3__launcher(params, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k3 substep }=-
+
+  // -={ START k4 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 6.66666666666666630e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k4_gfs);
+    rk_substep_4__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k4 substep }=-
+
+  // -={ START k5 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.72673164646011429e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k5_gfs);
+    rk_substep_5__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k5 substep }=-
+
+  // -={ START k6 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 8.27326835353988543e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k6_gfs);
+    rk_substep_6__launcher(params, k1_gfs, k2_gfs, k3_gfs, k4_gfs, k5_gfs, k6_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k6 substep }=-
+
+  // -={ START k7 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict k4_gfs = griddata[grid].gridfuncs.k4_gfs;
+    MAYBE_UNUSED REAL *restrict k5_gfs = griddata[grid].gridfuncs.k5_gfs;
+    MAYBE_UNUSED REAL *restrict k6_gfs = griddata[grid].gridfuncs.k6_gfs;
+    MAYBE_UNUSED REAL *restrict k7_gfs = griddata[grid].gridfuncs.k7_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k7_gfs);
+    rk_substep_7__launcher(params, k1_gfs, k3_gfs, k5_gfs, k6_gfs, k7_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k7 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK2_Heun.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK2_Heun.cu
@@ -1,0 +1,150 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k_odd_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_odd_gfsL = k_odd_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_2 = 1.0 / 2.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_2 = ConstCUDA(dblRK_Rational_1_2);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = MulCUDA(RK_Rational_1_2, MulCUDA(dt, k_odd_gfsL));
+    const REAL_CUDA_ARRAY __rk_exp_1 = FusedMulAddCUDA(dt, k_odd_gfsL, y_n_gfsL);
+    WriteCUDA(&y_nplus1_running_total_gfs[i], __rk_exp_0);
+    WriteCUDA(&k_odd_gfs[i], __rk_exp_1);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k_odd_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k_odd_gfs, y_n_gfs, y_nplus1_running_total_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k_even_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_even_gfsL = k_even_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
+    static const double dblRK_Rational_1_2 = 1.0 / 2.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_2 = ConstCUDA(dblRK_Rational_1_2);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = AddCUDA(y_n_gfsL, FusedMulAddCUDA(RK_Rational_1_2, MulCUDA(dt, k_even_gfsL), y_nplus1_running_total_gfsL));
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k_even_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k_even_gfs, y_n_gfs, y_nplus1_running_total_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * Method of Lines (MoL) for "RK2 Heun" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ RK2 Heun }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+  // -={ START k1 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k_odd_gfs);
+    rk_substep_1__launcher(params, k_odd_gfs, y_n_gfs, y_nplus1_running_total_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, k_odd_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, k_odd_gfs, k_even_gfs);
+    rk_substep_2__launcher(params, k_even_gfs, y_n_gfs, y_nplus1_running_total_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK2_MP.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK2_MP.cu
@@ -1,0 +1,150 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k_odd_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_odd_gfsL = k_odd_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_Integer_0 = 0.0;
+    const REAL_CUDA_ARRAY _Integer_0 = ConstCUDA(dbl_Integer_0);
+
+    static const double dblRK_Rational_1_2 = 1.0 / 2.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_2 = ConstCUDA(dblRK_Rational_1_2);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = _Integer_0;
+    const REAL_CUDA_ARRAY __rk_exp_1 = FusedMulAddCUDA(RK_Rational_1_2, MulCUDA(dt, k_odd_gfsL), y_n_gfsL);
+    WriteCUDA(&y_nplus1_running_total_gfs[i], __rk_exp_0);
+    WriteCUDA(&k_odd_gfs[i], __rk_exp_1);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k_odd_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k_odd_gfs, y_n_gfs, y_nplus1_running_total_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k_even_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_even_gfsL = k_even_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
+    const REAL_CUDA_ARRAY __rk_exp_0 = AddCUDA(y_n_gfsL, FusedMulAddCUDA(dt, k_even_gfsL, y_nplus1_running_total_gfsL));
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k_even_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k_even_gfs, y_n_gfs, y_nplus1_running_total_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * Method of Lines (MoL) for "RK2 MP" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ RK2 MP }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+  // -={ START k1 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k_odd_gfs);
+    rk_substep_1__launcher(params, k_odd_gfs, y_n_gfs, y_nplus1_running_total_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, k_odd_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 5.00000000000000000e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, k_odd_gfs, k_even_gfs);
+    rk_substep_2__launcher(params, k_even_gfs, y_n_gfs, y_nplus1_running_total_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK2_Ralston.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK2_Ralston.cu
@@ -1,0 +1,153 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k_odd_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_odd_gfsL = k_odd_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_4 = 1.0 / 4.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_4 = ConstCUDA(dblRK_Rational_1_4);
+
+    static const double dblRK_Rational_2_3 = 2.0 / 3.0;
+    const REAL_CUDA_ARRAY RK_Rational_2_3 = ConstCUDA(dblRK_Rational_2_3);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = MulCUDA(RK_Rational_1_4, MulCUDA(dt, k_odd_gfsL));
+    const REAL_CUDA_ARRAY __rk_exp_1 = FusedMulAddCUDA(RK_Rational_2_3, MulCUDA(dt, k_odd_gfsL), y_n_gfsL);
+    WriteCUDA(&y_nplus1_running_total_gfs[i], __rk_exp_0);
+    WriteCUDA(&k_odd_gfs[i], __rk_exp_1);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k_odd_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k_odd_gfs, y_n_gfs, y_nplus1_running_total_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k_even_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_even_gfsL = k_even_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
+    static const double dblRK_Rational_3_4 = 3.0 / 4.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_4 = ConstCUDA(dblRK_Rational_3_4);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = AddCUDA(y_n_gfsL, FusedMulAddCUDA(RK_Rational_3_4, MulCUDA(dt, k_even_gfsL), y_nplus1_running_total_gfsL));
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k_even_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k_even_gfs, y_n_gfs, y_nplus1_running_total_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * Method of Lines (MoL) for "RK2 Ralston" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ RK2 Ralston }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+  // -={ START k1 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k_odd_gfs);
+    rk_substep_1__launcher(params, k_odd_gfs, y_n_gfs, y_nplus1_running_total_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, k_odd_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 6.66666666666666630e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, k_odd_gfs, k_even_gfs);
+    rk_substep_2__launcher(params, k_even_gfs, y_n_gfs, y_nplus1_running_total_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK3.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK3.cu
@@ -1,0 +1,220 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_2 = 1.0 / 2.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_2 = ConstCUDA(dblRK_Rational_1_2);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_1_2, MulCUDA(k1_gfsL, dt), y_n_gfsL);
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dbl_Integer_2 = 2.0;
+    const REAL_CUDA_ARRAY _Integer_2 = ConstCUDA(dbl_Integer_2);
+
+    static const double dbl_NegativeOne_ = -1.0;
+    MAYBE_UNUSED const REAL_CUDA_ARRAY _NegativeOne_ = ConstCUDA(dbl_NegativeOne_);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(_Integer_2, MulCUDA(k2_gfsL, dt), NegFusedMulAddCUDA(k1_gfsL, dt, y_n_gfsL));
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * GPU Kernel: rk_substep_3_gpu.
+ * GPU Kernel to compute RK substep 3.
+ */
+__global__ static void rk_substep_3_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_6 = 1.0 / 6.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_6 = ConstCUDA(dblRK_Rational_1_6);
+
+    static const double dblRK_Rational_2_3 = 2.0 / 3.0;
+    const REAL_CUDA_ARRAY RK_Rational_2_3 = ConstCUDA(dblRK_Rational_2_3);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_1_6, FusedMulAddCUDA(k1_gfsL, dt, MulCUDA(k3_gfsL, dt)),
+                                                       FusedMulAddCUDA(RK_Rational_2_3, MulCUDA(k2_gfsL, dt), y_n_gfsL));
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_3_gpu
+
+/**
+ * Runge-Kutta function for substep 3.
+ */
+static void rk_substep_3__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_3_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_3_gpu failure");
+} // END FUNCTION rk_substep_3__launcher
+
+/**
+ * Method of Lines (MoL) for "RK3" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ RK3 }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+  // -={ START k1 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k1_gfs);
+    rk_substep_1__launcher(params, k1_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 5.00000000000000000e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k2_gfs);
+    rk_substep_2__launcher(params, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // -={ START k3 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k3_gfs);
+    rk_substep_3__launcher(params, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k3 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK3_Heun.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK3_Heun.cu
@@ -1,0 +1,240 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                        REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfsL = k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_3 = 1.0 / 3.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_3 = ConstCUDA(dblRK_Rational_1_3);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_1_3, MulCUDA(dt, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfsL), y_n_gfsL);
+    WriteCUDA(&k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                   REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                                                                  y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                        REAL *restrict y_n_gfs, REAL *restrict k2_or_y_nplus_a32_k2_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfsL = k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    const REAL k2_or_y_nplus_a32_k2_gfsL = k2_or_y_nplus_a32_k2_gfs[i];
+    static const double dblRK_Rational_1_4 = 1.0 / 4.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_4 = ConstCUDA(dblRK_Rational_1_4);
+
+    static const double dblRK_Rational_2_3 = 2.0 / 3.0;
+    const REAL_CUDA_ARRAY RK_Rational_2_3 = ConstCUDA(dblRK_Rational_2_3);
+
+    static const double dblRK_Rational_3_4 = 3.0 / 4.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_4 = ConstCUDA(dblRK_Rational_3_4);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_1_4, y_n_gfsL, MulCUDA(RK_Rational_3_4, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfsL));
+    const REAL_CUDA_ARRAY __rk_exp_1 = FusedMulAddCUDA(RK_Rational_2_3, MulCUDA(dt, k2_or_y_nplus_a32_k2_gfsL), y_n_gfsL);
+    WriteCUDA(&k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs[i], __rk_exp_0);
+    WriteCUDA(&k2_or_y_nplus_a32_k2_gfs[i], __rk_exp_1);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                   REAL *restrict y_n_gfs, REAL *restrict k2_or_y_nplus_a32_k2_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                                                                  y_n_gfs, k2_or_y_nplus_a32_k2_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * GPU Kernel: rk_substep_3_gpu.
+ * GPU Kernel to compute RK substep 3.
+ */
+__global__ static void rk_substep_3_gpu(const size_t streamid, REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                        REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfsL = k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_3_4 = 3.0 / 4.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_4 = ConstCUDA(dblRK_Rational_3_4);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_3_4, MulCUDA(dt, y_n_gfsL), k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfsL);
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_3_gpu
+
+/**
+ * Runge-Kutta function for substep 3.
+ */
+static void rk_substep_3__launcher(params_struct *restrict params, REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                   REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_3_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                                                                  y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_3_gpu failure");
+} // END FUNCTION rk_substep_3__launcher
+
+/**
+ * Method of Lines (MoL) for "RK3 Heun" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ RK3 Heun }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+
+  // In a diagonal RK3 method like this one, only 3 gridfunctions need be defined. Below implements this approach.
+  // Using y_n_gfs as input, k1 and apply boundary conditions
+  // -={ START k1 substep }=-
+  // RHS evaluation:
+  //  1. We will store k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs now as
+  //     ...  the update for the next rhs evaluation y_n + a21*k1*dt
+  // Post-RHS evaluation:
+  //  1. Apply post-RHS to y_n + a21*k1*dt
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs =
+        griddata[grid].gridfuncs.k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k2_or_y_nplus_a32_k2_gfs = griddata[grid].gridfuncs.k2_or_y_nplus_a32_k2_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs);
+    rk_substep_1__launcher(params, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  // RHS evaluation:
+  //    1. Reassign k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs to be the running total y_{n+1}; a32*k2*dt to the running total
+  //    2. Store k2_or_y_nplus_a32_k2_gfs now as y_n + a32*k2*dt
+  // Post-RHS evaluation:
+  //    1. Apply post-RHS to both y_n + a32*k2 (stored in k2_or_y_nplus_a32_k2_gfs)
+  //       ... and the y_{n+1} running total, as they have not been applied yet to k2-related gridfunctions
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 3.33333333333333315e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs =
+        griddata[grid].gridfuncs.k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k2_or_y_nplus_a32_k2_gfs = griddata[grid].gridfuncs.k2_or_y_nplus_a32_k2_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs, k2_or_y_nplus_a32_k2_gfs);
+    rk_substep_2__launcher(params, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs, y_n_gfs, k2_or_y_nplus_a32_k2_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, k2_or_y_nplus_a32_k2_gfs);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // -={ START k3 substep }=-
+  // RHS evaluation:
+  //    1. Add k3 to the running total and save to y_n
+  // Post-RHS evaluation:
+  //    1. Apply post-RHS to y_n
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 6.66666666666666630e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs =
+        griddata[grid].gridfuncs.k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k2_or_y_nplus_a32_k2_gfs = griddata[grid].gridfuncs.k2_or_y_nplus_a32_k2_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, k2_or_y_nplus_a32_k2_gfs, y_n_gfs);
+    rk_substep_3__launcher(params, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k3 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK3_Ralston.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK3_Ralston.cu
@@ -1,0 +1,245 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                        REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfsL = k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_2 = 1.0 / 2.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_2 = ConstCUDA(dblRK_Rational_1_2);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_1_2, MulCUDA(dt, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfsL), y_n_gfsL);
+    WriteCUDA(&k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                   REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                                                                  y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                        REAL *restrict k2_or_y_nplus_a32_k2_gfs, REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfsL = k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs[i];
+    const REAL k2_or_y_nplus_a32_k2_gfsL = k2_or_y_nplus_a32_k2_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_3 = 1.0 / 3.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_3 = ConstCUDA(dblRK_Rational_1_3);
+
+    static const double dblRK_Rational_3_4 = 3.0 / 4.0;
+    const REAL_CUDA_ARRAY RK_Rational_3_4 = ConstCUDA(dblRK_Rational_3_4);
+
+    static const double dblRK_Rational_4_9 = 4.0 / 9.0;
+    const REAL_CUDA_ARRAY RK_Rational_4_9 = ConstCUDA(dblRK_Rational_4_9);
+
+    static const double dblRK_Rational_5_9 = 5.0 / 9.0;
+    const REAL_CUDA_ARRAY RK_Rational_5_9 = ConstCUDA(dblRK_Rational_5_9);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 =
+        FusedMulAddCUDA(RK_Rational_5_9, y_n_gfsL,
+                        FusedMulAddCUDA(RK_Rational_1_3, MulCUDA(dt, k2_or_y_nplus_a32_k2_gfsL),
+                                        MulCUDA(RK_Rational_4_9, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfsL)));
+    const REAL_CUDA_ARRAY __rk_exp_1 = FusedMulAddCUDA(RK_Rational_3_4, MulCUDA(dt, k2_or_y_nplus_a32_k2_gfsL), y_n_gfsL);
+    WriteCUDA(&k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs[i], __rk_exp_0);
+    WriteCUDA(&k2_or_y_nplus_a32_k2_gfs[i], __rk_exp_1);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                   REAL *restrict k2_or_y_nplus_a32_k2_gfs, REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                                                                  k2_or_y_nplus_a32_k2_gfs, y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * GPU Kernel: rk_substep_3_gpu.
+ * GPU Kernel to compute RK substep 3.
+ */
+__global__ static void rk_substep_3_gpu(const size_t streamid, REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                        REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfsL = k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_4_9 = 4.0 / 9.0;
+    const REAL_CUDA_ARRAY RK_Rational_4_9 = ConstCUDA(dblRK_Rational_4_9);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_4_9, MulCUDA(dt, y_n_gfsL), k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfsL);
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_3_gpu
+
+/**
+ * Runge-Kutta function for substep 3.
+ */
+static void rk_substep_3__launcher(params_struct *restrict params, REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                   REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_3_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs,
+                                                                                  y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_3_gpu failure");
+} // END FUNCTION rk_substep_3__launcher
+
+/**
+ * Method of Lines (MoL) for "RK3 Ralston" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ RK3 Ralston }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+
+  // In a diagonal RK3 method like this one, only 3 gridfunctions need be defined. Below implements this approach.
+  // Using y_n_gfs as input, k1 and apply boundary conditions
+  // -={ START k1 substep }=-
+  // RHS evaluation:
+  //  1. We will store k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs now as
+  //     ...  the update for the next rhs evaluation y_n + a21*k1*dt
+  // Post-RHS evaluation:
+  //  1. Apply post-RHS to y_n + a21*k1*dt
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs =
+        griddata[grid].gridfuncs.k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k2_or_y_nplus_a32_k2_gfs = griddata[grid].gridfuncs.k2_or_y_nplus_a32_k2_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs);
+    rk_substep_1__launcher(params, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  // RHS evaluation:
+  //    1. Reassign k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs to be the running total y_{n+1}; a32*k2*dt to the running total
+  //    2. Store k2_or_y_nplus_a32_k2_gfs now as y_n + a32*k2*dt
+  // Post-RHS evaluation:
+  //    1. Apply post-RHS to both y_n + a32*k2 (stored in k2_or_y_nplus_a32_k2_gfs)
+  //       ... and the y_{n+1} running total, as they have not been applied yet to k2-related gridfunctions
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 5.00000000000000000e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs =
+        griddata[grid].gridfuncs.k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k2_or_y_nplus_a32_k2_gfs = griddata[grid].gridfuncs.k2_or_y_nplus_a32_k2_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs, k2_or_y_nplus_a32_k2_gfs);
+    rk_substep_2__launcher(params, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs, k2_or_y_nplus_a32_k2_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, k2_or_y_nplus_a32_k2_gfs);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // -={ START k3 substep }=-
+  // RHS evaluation:
+  //    1. Add k3 to the running total and save to y_n
+  // Post-RHS evaluation:
+  //    1. Apply post-RHS to y_n
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 7.50000000000000000e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs =
+        griddata[grid].gridfuncs.k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k2_or_y_nplus_a32_k2_gfs = griddata[grid].gridfuncs.k2_or_y_nplus_a32_k2_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, k2_or_y_nplus_a32_k2_gfs, y_n_gfs);
+    rk_substep_3__launcher(params, k1_or_y_nplus_a21_k1_or_y_nplus1_running_total_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k3 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK4.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__RK4.cu
@@ -1,0 +1,282 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k_odd_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_odd_gfsL = k_odd_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_2 = 1.0 / 2.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_2 = ConstCUDA(dblRK_Rational_1_2);
+
+    static const double dblRK_Rational_1_6 = 1.0 / 6.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_6 = ConstCUDA(dblRK_Rational_1_6);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = MulCUDA(RK_Rational_1_6, MulCUDA(dt, k_odd_gfsL));
+    const REAL_CUDA_ARRAY __rk_exp_1 = FusedMulAddCUDA(RK_Rational_1_2, MulCUDA(dt, k_odd_gfsL), y_n_gfsL);
+    WriteCUDA(&y_nplus1_running_total_gfs[i], __rk_exp_0);
+    WriteCUDA(&k_odd_gfs[i], __rk_exp_1);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k_odd_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k_odd_gfs, y_n_gfs, y_nplus1_running_total_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k_even_gfs, REAL *restrict y_nplus1_running_total_gfs,
+                                        REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_even_gfsL = k_even_gfs[i];
+    const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_2 = 1.0 / 2.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_2 = ConstCUDA(dblRK_Rational_1_2);
+
+    static const double dblRK_Rational_1_3 = 1.0 / 3.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_3 = ConstCUDA(dblRK_Rational_1_3);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_1_3, MulCUDA(dt, k_even_gfsL), y_nplus1_running_total_gfsL);
+    const REAL_CUDA_ARRAY __rk_exp_1 = FusedMulAddCUDA(RK_Rational_1_2, MulCUDA(dt, k_even_gfsL), y_n_gfsL);
+    WriteCUDA(&y_nplus1_running_total_gfs[i], __rk_exp_0);
+    WriteCUDA(&k_even_gfs[i], __rk_exp_1);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k_even_gfs, REAL *restrict y_nplus1_running_total_gfs,
+                                   REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k_even_gfs, y_nplus1_running_total_gfs, y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * GPU Kernel: rk_substep_3_gpu.
+ * GPU Kernel to compute RK substep 3.
+ */
+__global__ static void rk_substep_3_gpu(const size_t streamid, REAL *restrict k_odd_gfs, REAL *restrict y_nplus1_running_total_gfs,
+                                        REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_odd_gfsL = k_odd_gfs[i];
+    const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_3 = 1.0 / 3.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_3 = ConstCUDA(dblRK_Rational_1_3);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_1_3, MulCUDA(dt, k_odd_gfsL), y_nplus1_running_total_gfsL);
+    const REAL_CUDA_ARRAY __rk_exp_1 = FusedMulAddCUDA(dt, k_odd_gfsL, y_n_gfsL);
+    WriteCUDA(&y_nplus1_running_total_gfs[i], __rk_exp_0);
+    WriteCUDA(&k_odd_gfs[i], __rk_exp_1);
+  }
+} // END FUNCTION rk_substep_3_gpu
+
+/**
+ * Runge-Kutta function for substep 3.
+ */
+static void rk_substep_3__launcher(params_struct *restrict params, REAL *restrict k_odd_gfs, REAL *restrict y_nplus1_running_total_gfs,
+                                   REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_3_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k_odd_gfs, y_nplus1_running_total_gfs, y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_3_gpu failure");
+} // END FUNCTION rk_substep_3__launcher
+
+/**
+ * GPU Kernel: rk_substep_4_gpu.
+ * GPU Kernel to compute RK substep 4.
+ */
+__global__ static void rk_substep_4_gpu(const size_t streamid, REAL *restrict k_even_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_even_gfsL = k_even_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
+    static const double dblRK_Rational_1_6 = 1.0 / 6.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_6 = ConstCUDA(dblRK_Rational_1_6);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = AddCUDA(y_n_gfsL, FusedMulAddCUDA(RK_Rational_1_6, MulCUDA(dt, k_even_gfsL), y_nplus1_running_total_gfsL));
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_4_gpu
+
+/**
+ * Runge-Kutta function for substep 4.
+ */
+static void rk_substep_4__launcher(params_struct *restrict params, REAL *restrict k_even_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_4_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k_even_gfs, y_n_gfs, y_nplus1_running_total_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_4_gpu failure");
+} // END FUNCTION rk_substep_4__launcher
+
+/**
+ * Method of Lines (MoL) for "RK4" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ RK4 }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+  // -={ START k1 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k_odd_gfs);
+    rk_substep_1__launcher(params, k_odd_gfs, y_n_gfs, y_nplus1_running_total_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, k_odd_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 5.00000000000000000e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, k_odd_gfs, k_even_gfs);
+    rk_substep_2__launcher(params, k_even_gfs, y_nplus1_running_total_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, k_even_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // -={ START k3 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 5.00000000000000000e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, k_even_gfs, k_odd_gfs);
+    rk_substep_3__launcher(params, k_odd_gfs, y_nplus1_running_total_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, k_odd_gfs);
+  }
+  // -={ END k3 substep }=-
+
+  // -={ START k4 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, k_odd_gfs, k_even_gfs);
+    rk_substep_4__launcher(params, k_even_gfs, y_n_gfs, y_nplus1_running_total_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k4 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__SSPRK3.cu
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_CUDA__MoL_step_forward_in_time__SSPRK3.cu
@@ -1,0 +1,214 @@
+#include "BHaH_defines.h"
+#include "BHaH_function_prototypes.h"
+#include "intrinsics/cuda_intrinsics.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  const int tid0 = threadIdx.x + blockIdx.x * blockDim.x;                                                                                            \
+  const int stride0 = blockDim.x * gridDim.x;                                                                                                        \
+  for (int(ii) = (tid0);                                                                                                                             \
+       (ii) < d_params[streamid].Nxx_plus_2NGHOSTS0 * d_params[streamid].Nxx_plus_2NGHOSTS1 * d_params[streamid].Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;  \
+       (ii) += (stride0))
+/**
+ * GPU Kernel: rk_substep_1_gpu.
+ * GPU Kernel to compute RK substep 1.
+ */
+__global__ static void rk_substep_1_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                        const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(k1_gfsL, dt, y_n_gfsL);
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_1_gpu
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict y_n_gfs, REAL *restrict next_y_input_gfs,
+                                   const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_1_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_1_gpu failure");
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * GPU Kernel: rk_substep_2_gpu.
+ * GPU Kernel to compute RK substep 2.
+ */
+__global__ static void rk_substep_2_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                        REAL *restrict next_y_input_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_4 = 1.0 / 4.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_4 = ConstCUDA(dblRK_Rational_1_4);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_1_4, FusedMulAddCUDA(k1_gfsL, dt, MulCUDA(k2_gfsL, dt)), y_n_gfsL);
+    WriteCUDA(&next_y_input_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_2_gpu
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict next_y_input_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_2_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_2_gpu failure");
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * GPU Kernel: rk_substep_3_gpu.
+ * GPU Kernel to compute RK substep 3.
+ */
+__global__ static void rk_substep_3_gpu(const size_t streamid, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                        REAL *restrict y_n_gfs, const REAL dt) {
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k1_gfsL = k1_gfs[i];
+    const REAL k2_gfsL = k2_gfs[i];
+    const REAL k3_gfsL = k3_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    static const double dblRK_Rational_1_6 = 1.0 / 6.0;
+    const REAL_CUDA_ARRAY RK_Rational_1_6 = ConstCUDA(dblRK_Rational_1_6);
+
+    static const double dblRK_Rational_2_3 = 2.0 / 3.0;
+    const REAL_CUDA_ARRAY RK_Rational_2_3 = ConstCUDA(dblRK_Rational_2_3);
+
+    const REAL_CUDA_ARRAY __rk_exp_0 = FusedMulAddCUDA(RK_Rational_1_6, FusedMulAddCUDA(k1_gfsL, dt, MulCUDA(k2_gfsL, dt)),
+                                                       FusedMulAddCUDA(RK_Rational_2_3, MulCUDA(k3_gfsL, dt), y_n_gfsL));
+    WriteCUDA(&y_n_gfs[i], __rk_exp_0);
+  }
+} // END FUNCTION rk_substep_3_gpu
+
+/**
+ * Runge-Kutta function for substep 3.
+ */
+static void rk_substep_3__launcher(params_struct *restrict params, REAL *restrict k1_gfs, REAL *restrict k2_gfs, REAL *restrict k3_gfs,
+                                   REAL *restrict y_n_gfs, const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  MAYBE_UNUSED const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  const size_t threads_in_x_dir = 32;
+  const size_t threads_in_y_dir = 1;
+  const size_t threads_in_z_dir = 1;
+  dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
+  dim3 blocks_per_grid((Ntot + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  size_t sm = 0;
+  size_t streamid = params->grid_idx % NUM_STREAMS;
+  rk_substep_3_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, dt);
+  cudaCheckErrors(cudaKernel, "rk_substep_3_gpu failure");
+} // END FUNCTION rk_substep_3__launcher
+
+/**
+ * Method of Lines (MoL) for "SSPRK3" method: Step forward one full timestep.
+ *
+ */
+void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_struct *restrict griddata) {
+
+  // C code implementation of -={ SSPRK3 }=- Method of Lines timestepping.
+
+  // First set the initial time:
+  const REAL time_start = commondata->time;
+  // -={ START k1 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, y_n_gfs, k1_gfs);
+    rk_substep_1__launcher(params, k1_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k1 substep }=-
+
+  // -={ START k2 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k2_gfs);
+    rk_substep_2__launcher(params, k1_gfs, k2_gfs, y_n_gfs, next_y_input_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, next_y_input_gfs);
+  }
+  // -={ END k2 substep }=-
+
+  // -={ START k3 substep }=-
+  for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+    commondata->time = time_start + 5.00000000000000000e-01 * commondata->dt;
+    // Set gridfunction aliases from gridfuncs struct
+    // y_n gridfunctions
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    // Temporary timelevel & AUXEVOL gridfunctions:
+    MAYBE_UNUSED REAL *restrict next_y_input_gfs = griddata[grid].gridfuncs.next_y_input_gfs;
+    MAYBE_UNUSED REAL *restrict k1_gfs = griddata[grid].gridfuncs.k1_gfs;
+    MAYBE_UNUSED REAL *restrict k2_gfs = griddata[grid].gridfuncs.k2_gfs;
+    MAYBE_UNUSED REAL *restrict k3_gfs = griddata[grid].gridfuncs.k3_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
+    for (int ww = 0; ww < 3; ww++)
+      xx[ww] = griddata[grid].xx[ww];
+    rhs_eval(commondata, params, rfmstruct, auxevol_gfs, next_y_input_gfs, k3_gfs);
+    rk_substep_3__launcher(params, k1_gfs, k2_gfs, k3_gfs, y_n_gfs, commondata->dt);
+    if (strncmp(commondata->outer_bc_type, "extrapolation", 50) == 0)
+      apply_bcs_outerextrap_and_inner(commondata, params, bcstruct, y_n_gfs);
+  }
+  // -={ END k3 substep }=-
+
+  // Adding dt to commondata->time many times will induce roundoff error,
+  //   so here we set time based on the iteration number.
+  commondata->time = (REAL)(commondata->nn + 1) * commondata->dt;
+
+  // Finally, increment the timestep n:
+  commondata->nn++;
+} // END FUNCTION MoL_step_forward_in_time

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_MoL_step_forward_in_time.c
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_MoL_step_forward_in_time.c
@@ -1,6 +1,118 @@
 #include "BHaH_defines.h"
 #include "BHaH_function_prototypes.h"
 /**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1(params_struct *restrict params, REAL *restrict k_odd_gfs, REAL *restrict y_n_gfs, REAL *restrict y_nplus1_running_total_gfs,
+                         const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_odd_gfsL = k_odd_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    const REAL RK_Rational_1_6 = 1.0 / 6.0;
+    const REAL RK_Rational_1_2 = 1.0 / 2.0;
+    y_nplus1_running_total_gfs[i] = RK_Rational_1_6 * dt * k_odd_gfsL;
+    k_odd_gfs[i] = RK_Rational_1_2 * dt * k_odd_gfsL + y_n_gfsL;
+  }
+} // END FUNCTION rk_substep_1
+
+/**
+ * Runge-Kutta function for substep 1.
+ */
+static void rk_substep_1__launcher(params_struct *restrict params, REAL *restrict k_odd_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  rk_substep_1(params, k_odd_gfs, y_n_gfs, y_nplus1_running_total_gfs, dt);
+} // END FUNCTION rk_substep_1__launcher
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2(params_struct *restrict params, REAL *restrict k_even_gfs, REAL *restrict y_nplus1_running_total_gfs, REAL *restrict y_n_gfs,
+                         const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_even_gfsL = k_even_gfs[i];
+    const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    const REAL RK_Rational_1_3 = 1.0 / 3.0;
+    const REAL RK_Rational_1_2 = 1.0 / 2.0;
+    y_nplus1_running_total_gfs[i] = RK_Rational_1_3 * dt * k_even_gfsL + y_nplus1_running_total_gfsL;
+    k_even_gfs[i] = RK_Rational_1_2 * dt * k_even_gfsL + y_n_gfsL;
+  }
+} // END FUNCTION rk_substep_2
+
+/**
+ * Runge-Kutta function for substep 2.
+ */
+static void rk_substep_2__launcher(params_struct *restrict params, REAL *restrict k_even_gfs, REAL *restrict y_nplus1_running_total_gfs,
+                                   REAL *restrict y_n_gfs, const REAL dt) {
+  rk_substep_2(params, k_even_gfs, y_nplus1_running_total_gfs, y_n_gfs, dt);
+} // END FUNCTION rk_substep_2__launcher
+
+/**
+ * Runge-Kutta function for substep 3.
+ */
+static void rk_substep_3(params_struct *restrict params, REAL *restrict k_odd_gfs, REAL *restrict y_nplus1_running_total_gfs, REAL *restrict y_n_gfs,
+                         const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_odd_gfsL = k_odd_gfs[i];
+    const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    const REAL RK_Rational_1_3 = 1.0 / 3.0;
+    y_nplus1_running_total_gfs[i] = RK_Rational_1_3 * dt * k_odd_gfsL + y_nplus1_running_total_gfsL;
+    k_odd_gfs[i] = dt * k_odd_gfsL + y_n_gfsL;
+  }
+} // END FUNCTION rk_substep_3
+
+/**
+ * Runge-Kutta function for substep 3.
+ */
+static void rk_substep_3__launcher(params_struct *restrict params, REAL *restrict k_odd_gfs, REAL *restrict y_nplus1_running_total_gfs,
+                                   REAL *restrict y_n_gfs, const REAL dt) {
+  rk_substep_3(params, k_odd_gfs, y_nplus1_running_total_gfs, y_n_gfs, dt);
+} // END FUNCTION rk_substep_3__launcher
+
+/**
+ * Runge-Kutta function for substep 4.
+ */
+static void rk_substep_4(params_struct *restrict params, REAL *restrict k_even_gfs, REAL *restrict y_n_gfs, REAL *restrict y_nplus1_running_total_gfs,
+                         const REAL dt) {
+  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
+  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
+  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
+  const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
+
+  LOOP_ALL_GFS_GPS(i) {
+    const REAL k_even_gfsL = k_even_gfs[i];
+    const REAL y_n_gfsL = y_n_gfs[i];
+    const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
+    const REAL RK_Rational_1_6 = 1.0 / 6.0;
+    y_n_gfs[i] = RK_Rational_1_6 * dt * k_even_gfsL + y_n_gfsL + y_nplus1_running_total_gfsL;
+  }
+} // END FUNCTION rk_substep_4
+
+/**
+ * Runge-Kutta function for substep 4.
+ */
+static void rk_substep_4__launcher(params_struct *restrict params, REAL *restrict k_even_gfs, REAL *restrict y_n_gfs,
+                                   REAL *restrict y_nplus1_running_total_gfs, const REAL dt) {
+  rk_substep_4(params, k_even_gfs, y_n_gfs, y_nplus1_running_total_gfs, dt);
+} // END FUNCTION rk_substep_4__launcher
+
+/**
  * Method of Lines (MoL) for "RK4" method: Step forward one full timestep.
  *
  */
@@ -15,26 +127,21 @@ void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_s
     commondata->time = time_start + 0.00000000000000000e+00 * commondata->dt;
     // Set gridfunction aliases from gridfuncs struct
     // y_n gridfunctions
-    REAL MAYBE_UNUSED *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
     // Temporary timelevel & AUXEVOL gridfunctions:
-    REAL MAYBE_UNUSED *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
-    REAL MAYBE_UNUSED *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
-    REAL MAYBE_UNUSED *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
-    REAL MAYBE_UNUSED *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
-    params_struct *restrict params = &griddata[grid].params;
-    REAL MAYBE_UNUSED *restrict xx[3];
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
     for (int ww = 0; ww < 3; ww++)
       xx[ww] = griddata[grid].xx[ww];
-    const int Nxx_plus_2NGHOSTS0 = griddata[grid].params.Nxx_plus_2NGHOSTS0;
-    const int Nxx_plus_2NGHOSTS1 = griddata[grid].params.Nxx_plus_2NGHOSTS1;
-    const int Nxx_plus_2NGHOSTS2 = griddata[grid].params.Nxx_plus_2NGHOSTS2;
+    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = griddata[grid].params.Nxx_plus_2NGHOSTS0;
+    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = griddata[grid].params.Nxx_plus_2NGHOSTS1;
+    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = griddata[grid].params.Nxx_plus_2NGHOSTS2;
     rhs_eval(Nxx, Nxx_plus_2NGHOSTS, dxx, y_n_gfs, k_odd_gfs);
-    LOOP_ALL_GFS_GPS(i) {
-      const REAL k_odd_gfsL = k_odd_gfs[i];
-      const REAL y_n_gfsL = y_n_gfs[i];
-      y_nplus1_running_total_gfs[i] = (1.0 / 6.0) * commondata->dt * k_odd_gfsL;
-      k_odd_gfs[i] = (1.0 / 2.0) * commondata->dt * k_odd_gfsL + y_n_gfsL;
-    }
+    rk_substep_1__launcher(params, k_odd_gfs, y_n_gfs, y_nplus1_running_total_gfs, commondata->dt);
     apply_bcs(Nxx, Nxx_plus_2NGHOSTS, k_odd_gfs);
   }
   // -={ END k1 substep }=-
@@ -44,27 +151,21 @@ void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_s
     commondata->time = time_start + 5.00000000000000000e-01 * commondata->dt;
     // Set gridfunction aliases from gridfuncs struct
     // y_n gridfunctions
-    REAL MAYBE_UNUSED *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
     // Temporary timelevel & AUXEVOL gridfunctions:
-    REAL MAYBE_UNUSED *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
-    REAL MAYBE_UNUSED *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
-    REAL MAYBE_UNUSED *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
-    REAL MAYBE_UNUSED *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
-    params_struct *restrict params = &griddata[grid].params;
-    REAL MAYBE_UNUSED *restrict xx[3];
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
     for (int ww = 0; ww < 3; ww++)
       xx[ww] = griddata[grid].xx[ww];
-    const int Nxx_plus_2NGHOSTS0 = griddata[grid].params.Nxx_plus_2NGHOSTS0;
-    const int Nxx_plus_2NGHOSTS1 = griddata[grid].params.Nxx_plus_2NGHOSTS1;
-    const int Nxx_plus_2NGHOSTS2 = griddata[grid].params.Nxx_plus_2NGHOSTS2;
+    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = griddata[grid].params.Nxx_plus_2NGHOSTS0;
+    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = griddata[grid].params.Nxx_plus_2NGHOSTS1;
+    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = griddata[grid].params.Nxx_plus_2NGHOSTS2;
     rhs_eval(Nxx, Nxx_plus_2NGHOSTS, dxx, k_odd_gfs, k_even_gfs);
-    LOOP_ALL_GFS_GPS(i) {
-      const REAL k_even_gfsL = k_even_gfs[i];
-      const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
-      const REAL y_n_gfsL = y_n_gfs[i];
-      y_nplus1_running_total_gfs[i] = (1.0 / 3.0) * commondata->dt * k_even_gfsL + y_nplus1_running_total_gfsL;
-      k_even_gfs[i] = (1.0 / 2.0) * commondata->dt * k_even_gfsL + y_n_gfsL;
-    }
+    rk_substep_2__launcher(params, k_even_gfs, y_nplus1_running_total_gfs, y_n_gfs, commondata->dt);
     apply_bcs(Nxx, Nxx_plus_2NGHOSTS, k_even_gfs);
   }
   // -={ END k2 substep }=-
@@ -74,27 +175,21 @@ void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_s
     commondata->time = time_start + 5.00000000000000000e-01 * commondata->dt;
     // Set gridfunction aliases from gridfuncs struct
     // y_n gridfunctions
-    REAL MAYBE_UNUSED *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
     // Temporary timelevel & AUXEVOL gridfunctions:
-    REAL MAYBE_UNUSED *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
-    REAL MAYBE_UNUSED *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
-    REAL MAYBE_UNUSED *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
-    REAL MAYBE_UNUSED *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
-    params_struct *restrict params = &griddata[grid].params;
-    REAL MAYBE_UNUSED *restrict xx[3];
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
     for (int ww = 0; ww < 3; ww++)
       xx[ww] = griddata[grid].xx[ww];
-    const int Nxx_plus_2NGHOSTS0 = griddata[grid].params.Nxx_plus_2NGHOSTS0;
-    const int Nxx_plus_2NGHOSTS1 = griddata[grid].params.Nxx_plus_2NGHOSTS1;
-    const int Nxx_plus_2NGHOSTS2 = griddata[grid].params.Nxx_plus_2NGHOSTS2;
+    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = griddata[grid].params.Nxx_plus_2NGHOSTS0;
+    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = griddata[grid].params.Nxx_plus_2NGHOSTS1;
+    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = griddata[grid].params.Nxx_plus_2NGHOSTS2;
     rhs_eval(Nxx, Nxx_plus_2NGHOSTS, dxx, k_even_gfs, k_odd_gfs);
-    LOOP_ALL_GFS_GPS(i) {
-      const REAL k_odd_gfsL = k_odd_gfs[i];
-      const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
-      const REAL y_n_gfsL = y_n_gfs[i];
-      y_nplus1_running_total_gfs[i] = (1.0 / 3.0) * commondata->dt * k_odd_gfsL + y_nplus1_running_total_gfsL;
-      k_odd_gfs[i] = commondata->dt * k_odd_gfsL + y_n_gfsL;
-    }
+    rk_substep_3__launcher(params, k_odd_gfs, y_nplus1_running_total_gfs, y_n_gfs, commondata->dt);
     apply_bcs(Nxx, Nxx_plus_2NGHOSTS, k_odd_gfs);
   }
   // -={ END k3 substep }=-
@@ -104,26 +199,21 @@ void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_s
     commondata->time = time_start + 1.00000000000000000e+00 * commondata->dt;
     // Set gridfunction aliases from gridfuncs struct
     // y_n gridfunctions
-    REAL MAYBE_UNUSED *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
+    MAYBE_UNUSED REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
     // Temporary timelevel & AUXEVOL gridfunctions:
-    REAL MAYBE_UNUSED *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
-    REAL MAYBE_UNUSED *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
-    REAL MAYBE_UNUSED *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
-    REAL MAYBE_UNUSED *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
-    params_struct *restrict params = &griddata[grid].params;
-    REAL MAYBE_UNUSED *restrict xx[3];
+    MAYBE_UNUSED REAL *restrict y_nplus1_running_total_gfs = griddata[grid].gridfuncs.y_nplus1_running_total_gfs;
+    MAYBE_UNUSED REAL *restrict k_odd_gfs = griddata[grid].gridfuncs.k_odd_gfs;
+    MAYBE_UNUSED REAL *restrict k_even_gfs = griddata[grid].gridfuncs.k_even_gfs;
+    MAYBE_UNUSED REAL *restrict auxevol_gfs = griddata[grid].gridfuncs.auxevol_gfs;
+    MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
+    MAYBE_UNUSED REAL *restrict xx[3];
     for (int ww = 0; ww < 3; ww++)
       xx[ww] = griddata[grid].xx[ww];
-    const int Nxx_plus_2NGHOSTS0 = griddata[grid].params.Nxx_plus_2NGHOSTS0;
-    const int Nxx_plus_2NGHOSTS1 = griddata[grid].params.Nxx_plus_2NGHOSTS1;
-    const int Nxx_plus_2NGHOSTS2 = griddata[grid].params.Nxx_plus_2NGHOSTS2;
+    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = griddata[grid].params.Nxx_plus_2NGHOSTS0;
+    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = griddata[grid].params.Nxx_plus_2NGHOSTS1;
+    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = griddata[grid].params.Nxx_plus_2NGHOSTS2;
     rhs_eval(Nxx, Nxx_plus_2NGHOSTS, dxx, k_odd_gfs, k_even_gfs);
-    LOOP_ALL_GFS_GPS(i) {
-      const REAL k_even_gfsL = k_even_gfs[i];
-      const REAL y_n_gfsL = y_n_gfs[i];
-      const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
-      y_n_gfs[i] = (1.0 / 6.0) * commondata->dt * k_even_gfsL + y_n_gfsL + y_nplus1_running_total_gfsL;
-    }
+    rk_substep_4__launcher(params, k_even_gfs, y_n_gfs, y_nplus1_running_total_gfs, commondata->dt);
     apply_bcs(Nxx, Nxx_plus_2NGHOSTS, y_n_gfs);
   }
   // -={ END k4 substep }=-

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_MoL_step_forward_in_time.c
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/tests/MoL_MoL_step_forward_in_time.c
@@ -1,15 +1,15 @@
 #include "BHaH_defines.h"
 #include "BHaH_function_prototypes.h"
+
+#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
+  _Pragma("omp parallel for") for (int(ii) = 0;                                                                                                      \
+                                   (ii) < params->Nxx_plus_2NGHOSTS0 * params->Nxx_plus_2NGHOSTS1 * params->Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;       \
+                                   (ii)++)
 /**
  * Runge-Kutta function for substep 1.
  */
 static void rk_substep_1(params_struct *restrict params, REAL *restrict k_odd_gfs, REAL *restrict y_n_gfs, REAL *restrict y_nplus1_running_total_gfs,
                          const REAL dt) {
-  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
-  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
-  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
-  const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
-
   LOOP_ALL_GFS_GPS(i) {
     const REAL k_odd_gfsL = k_odd_gfs[i];
     const REAL y_n_gfsL = y_n_gfs[i];
@@ -33,11 +33,6 @@ static void rk_substep_1__launcher(params_struct *restrict params, REAL *restric
  */
 static void rk_substep_2(params_struct *restrict params, REAL *restrict k_even_gfs, REAL *restrict y_nplus1_running_total_gfs, REAL *restrict y_n_gfs,
                          const REAL dt) {
-  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
-  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
-  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
-  const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
-
   LOOP_ALL_GFS_GPS(i) {
     const REAL k_even_gfsL = k_even_gfs[i];
     const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
@@ -62,11 +57,6 @@ static void rk_substep_2__launcher(params_struct *restrict params, REAL *restric
  */
 static void rk_substep_3(params_struct *restrict params, REAL *restrict k_odd_gfs, REAL *restrict y_nplus1_running_total_gfs, REAL *restrict y_n_gfs,
                          const REAL dt) {
-  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
-  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
-  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
-  const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
-
   LOOP_ALL_GFS_GPS(i) {
     const REAL k_odd_gfsL = k_odd_gfs[i];
     const REAL y_nplus1_running_total_gfsL = y_nplus1_running_total_gfs[i];
@@ -90,11 +80,6 @@ static void rk_substep_3__launcher(params_struct *restrict params, REAL *restric
  */
 static void rk_substep_4(params_struct *restrict params, REAL *restrict k_even_gfs, REAL *restrict y_n_gfs, REAL *restrict y_nplus1_running_total_gfs,
                          const REAL dt) {
-  const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
-  const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
-  const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
-  const int Ntot = Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS;
-
   LOOP_ALL_GFS_GPS(i) {
     const REAL k_even_gfsL = k_even_gfs[i];
     const REAL y_n_gfsL = y_n_gfs[i];
@@ -137,9 +122,6 @@ void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_s
     MAYBE_UNUSED REAL *restrict xx[3];
     for (int ww = 0; ww < 3; ww++)
       xx[ww] = griddata[grid].xx[ww];
-    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = griddata[grid].params.Nxx_plus_2NGHOSTS0;
-    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = griddata[grid].params.Nxx_plus_2NGHOSTS1;
-    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = griddata[grid].params.Nxx_plus_2NGHOSTS2;
     rhs_eval(Nxx, Nxx_plus_2NGHOSTS, dxx, y_n_gfs, k_odd_gfs);
     rk_substep_1__launcher(params, k_odd_gfs, y_n_gfs, y_nplus1_running_total_gfs, commondata->dt);
     apply_bcs(Nxx, Nxx_plus_2NGHOSTS, k_odd_gfs);
@@ -161,9 +143,6 @@ void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_s
     MAYBE_UNUSED REAL *restrict xx[3];
     for (int ww = 0; ww < 3; ww++)
       xx[ww] = griddata[grid].xx[ww];
-    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = griddata[grid].params.Nxx_plus_2NGHOSTS0;
-    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = griddata[grid].params.Nxx_plus_2NGHOSTS1;
-    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = griddata[grid].params.Nxx_plus_2NGHOSTS2;
     rhs_eval(Nxx, Nxx_plus_2NGHOSTS, dxx, k_odd_gfs, k_even_gfs);
     rk_substep_2__launcher(params, k_even_gfs, y_nplus1_running_total_gfs, y_n_gfs, commondata->dt);
     apply_bcs(Nxx, Nxx_plus_2NGHOSTS, k_even_gfs);
@@ -185,9 +164,6 @@ void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_s
     MAYBE_UNUSED REAL *restrict xx[3];
     for (int ww = 0; ww < 3; ww++)
       xx[ww] = griddata[grid].xx[ww];
-    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = griddata[grid].params.Nxx_plus_2NGHOSTS0;
-    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = griddata[grid].params.Nxx_plus_2NGHOSTS1;
-    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = griddata[grid].params.Nxx_plus_2NGHOSTS2;
     rhs_eval(Nxx, Nxx_plus_2NGHOSTS, dxx, k_even_gfs, k_odd_gfs);
     rk_substep_3__launcher(params, k_odd_gfs, y_nplus1_running_total_gfs, y_n_gfs, commondata->dt);
     apply_bcs(Nxx, Nxx_plus_2NGHOSTS, k_odd_gfs);
@@ -209,9 +185,6 @@ void MoL_step_forward_in_time(commondata_struct *restrict commondata, griddata_s
     MAYBE_UNUSED REAL *restrict xx[3];
     for (int ww = 0; ww < 3; ww++)
       xx[ww] = griddata[grid].xx[ww];
-    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = griddata[grid].params.Nxx_plus_2NGHOSTS0;
-    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = griddata[grid].params.Nxx_plus_2NGHOSTS1;
-    MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = griddata[grid].params.Nxx_plus_2NGHOSTS2;
     rhs_eval(Nxx, Nxx_plus_2NGHOSTS, dxx, k_odd_gfs, k_even_gfs);
     rk_substep_4__launcher(params, k_even_gfs, y_n_gfs, y_nplus1_running_total_gfs, commondata->dt);
     apply_bcs(Nxx, Nxx_plus_2NGHOSTS, y_n_gfs);

--- a/nrpy/infrastructures/BHaH/tests/BHaH_defines_h_BHaH_defines.c
+++ b/nrpy/infrastructures/BHaH/tests/BHaH_defines_h_BHaH_defines.c
@@ -108,8 +108,7 @@ typedef struct __MoL_gridfunctions_struct__ {
   REAL *restrict diagnostic_output_gfs2;
 } MoL_gridfunctions_struct;
 
-#define LOOP_ALL_GFS_GPS(ii)                                                                                                                         \
-  _Pragma("omp parallel for") for (int(ii) = 0; (ii) < Nxx_plus_2NGHOSTS0 * Nxx_plus_2NGHOSTS1 * Nxx_plus_2NGHOSTS2 * NUM_EVOL_GFS; (ii)++)
+#define LOOP_ALL_GFS_GPS(ii) _Pragma("omp parallel for") for (int(ii) = 0; (ii) < Ntot; (ii)++)
 
 //********************************************
 // Basic definitions for module grid:

--- a/nrpy/infrastructures/BHaH/tests/BHaH_defines_h_BHaH_defines.c
+++ b/nrpy/infrastructures/BHaH/tests/BHaH_defines_h_BHaH_defines.c
@@ -108,8 +108,6 @@ typedef struct __MoL_gridfunctions_struct__ {
   REAL *restrict diagnostic_output_gfs2;
 } MoL_gridfunctions_struct;
 
-#define LOOP_ALL_GFS_GPS(ii) _Pragma("omp parallel for") for (int(ii) = 0; (ii) < Ntot; (ii)++)
-
 //********************************************
 // Basic definitions for module grid:
 


### PR DESCRIPTION
The objective of this PR is to refactor MoL to accommodate additional parallelization strategies such as CUDA.  This requires taking a more functional approach to the MoL algorithm.  This includes replacing rk substep loops in the MoL algorithm with intermediate substep launchers.  Depending on the parallelization strategy, these launchers will call either the CPU or a CUDA global kernel.

Minor revisions:
* update SIMD intrinsics path to be consistent with the rest of nrpy
* update position of `MAYBE UNUSED` to be consistent with recent PR

Note:  
* The current revised version has been incorporated into NRPyGPU and generates the expected code for NRPyEllipticGPU
* @nishitajadoo I have not been able to test with SuperB