### PR TITLE
Change griddata member, rfmstruct, to a pointer

### DIFF
--- a/nrpy/infrastructures/BHaH/BHaH_defines_h.py
+++ b/nrpy/infrastructures/BHaH/BHaH_defines_h.py
@@ -67,7 +67,7 @@ def register_griddata_struct_and_return_griddata_struct_str(
         if enable_rfm_precompute:
             griddata_commondata.register_griddata_commondata(
                 "reference_metric",
-                "rfm_struct rfmstruct",
+                "rfm_struct* rfmstruct",
                 "includes e.g., 1D arrays of reference metric quantities",
             )
 

--- a/nrpy/infrastructures/BHaH/MoLtimestepping/MoL_step_forward.py
+++ b/nrpy/infrastructures/BHaH/MoLtimestepping/MoL_step_forward.py
@@ -126,7 +126,7 @@ MAYBE_UNUSED REAL *restrict {y_n_gridfunctions} = {gf_prefix}{y_n_gridfunctions}
 MAYBE_UNUSED params_struct *restrict params = &griddata[grid].params;
 """
     if enable_rfm_precompute:
-        gf_aliases += "MAYBE_UNUSED const rfm_struct *restrict rfmstruct = &griddata[grid].rfmstruct;\n"
+        gf_aliases += "MAYBE_UNUSED const rfm_struct *restrict rfmstruct = griddata[grid].rfmstruct;\n"
     else:
         gf_aliases += "MAYBE_UNUSED REAL *restrict xx[3]; for(int ww=0;ww<3;ww++) xx[ww] = griddata[grid].xx[ww];\n"
     if enable_curviBCs:

--- a/nrpy/infrastructures/BHaH/bhah_lib.py
+++ b/nrpy/infrastructures/BHaH/bhah_lib.py
@@ -46,7 +46,7 @@ numerical_grids_and_timestep(commondata, griddata, calling_for_first_time);
 
 // Step 1.f: Allocate memory for all gridfunctions
 for(int grid = 0; grid < n_grids; grid++) {
-  MoL_malloc_y_n_gfs(commondata, &griddata[grid].params, &griddata[grid].gridfuncs); 
+  MoL_malloc_y_n_gfs(commondata, &griddata[grid].params, &griddata[grid].gridfuncs);
   MoL_malloc_non_y_n_gfs(commondata, &griddata[grid].params, &griddata[grid].gridfuncs);
 }
 
@@ -87,7 +87,7 @@ def register_CFunction_bhah_finalize() -> None:
     for(int grid = 0; grid < commondata->NUMGRIDS; grid++) {
               MoL_free_memory_y_n_gfs(&griddata[grid].gridfuncs);
               MoL_free_memory_non_y_n_gfs(&griddata[grid].gridfuncs);
-      rfm_precompute_free(commondata, &griddata[grid].params, &griddata[grid].rfmstruct);
+      rfm_precompute_free(commondata, &griddata[grid].params, griddata[grid].rfmstruct);
     }
     free(bhah_struct->commondata);
     free(bhah_struct->griddata);

--- a/nrpy/infrastructures/BHaH/general_relativity/BSSN_C_codegen_library.py
+++ b/nrpy/infrastructures/BHaH/general_relativity/BSSN_C_codegen_library.py
@@ -257,9 +257,9 @@ if(fabs(round(currtime / outevery) * outevery - currtime) < 0.5*currdt) {
     {
 """
     if use_Ricci_eval_func:
-        body += "Ricci_eval(commondata, params, &griddata[grid].rfmstruct, y_n_gfs, auxevol_gfs);\n"
+        body += "Ricci_eval(commondata, params, griddata[grid].rfmstruct, y_n_gfs, auxevol_gfs);\n"
     body += r"""
-      constraints_eval(commondata, params, &griddata[grid].rfmstruct, y_n_gfs, auxevol_gfs, diagnostic_output_gfs);
+      constraints_eval(commondata, params, griddata[grid].rfmstruct, y_n_gfs, auxevol_gfs, diagnostic_output_gfs);
     }
 
     // 0D output

--- a/nrpy/infrastructures/BHaH/griddata_commondata.py
+++ b/nrpy/infrastructures/BHaH/griddata_commondata.py
@@ -109,7 +109,8 @@ except perhaps non_y_n_gfs (e.g., after a regrid, in which non_y_n_gfs are freed
   for(int grid=0;grid<commondata->NUMGRIDS;grid++) {
 """
     if enable_rfm_precompute:
-        body += "  rfm_precompute_free(commondata, &griddata[grid].params, &griddata[grid].rfmstruct);\n"
+        body += "  rfm_precompute_free(commondata, &griddata[grid].params, griddata[grid].rfmstruct);\n"
+        body += "  free(griddata[grid].rfmstruct);\n"
     if enable_CurviBCs:
         body += r"""
   free(griddata[grid].bcstruct.inner_bc_array);

--- a/nrpy/infrastructures/BHaH/nrpyelliptic/conformally_flat_C_codegen_library.py
+++ b/nrpy/infrastructures/BHaH/nrpyelliptic/conformally_flat_C_codegen_library.py
@@ -511,7 +511,7 @@ def register_CFunction_diagnostics(
 
   // Set params and rfm_struct
   params_struct *restrict params = &griddata[grid].params;
-  const rfm_struct *restrict rfmstruct = &griddata[grid].rfmstruct;
+  const rfm_struct *restrict rfmstruct = griddata[grid].rfmstruct;
 #include "set_CodeParameters.h"
 
   // Compute Hamiltonian constraint violation and store it at diagnostic_output_gfs

--- a/nrpy/infrastructures/BHaH/numerical_grids_and_timestep.py
+++ b/nrpy/infrastructures/BHaH/numerical_grids_and_timestep.py
@@ -314,8 +314,9 @@ def register_CFunction_numerical_grids_and_timestep(
     body += "\n// Step 1.d: Allocate memory for and define reference-metric precomputation lookup tables\n"
     if enable_rfm_precompute:
         body += r"""for(int grid=0; grid<commondata->NUMGRIDS; grid++) {
-  rfm_precompute_malloc(commondata, &griddata[grid].params, &griddata[grid].rfmstruct);
-  rfm_precompute_defines(commondata, &griddata[grid].params, &griddata[grid].rfmstruct, griddata[grid].xx);
+  griddata[grid].rfmstruct = (rfm_struct *)malloc(sizeof(rfm_struct));
+  rfm_precompute_malloc(commondata, &griddata[grid].params, griddata[grid].rfmstruct);
+  rfm_precompute_defines(commondata, &griddata[grid].params, griddata[grid].rfmstruct, griddata[grid].xx);
 }
 """
     else:

--- a/nrpy/infrastructures/superB/MoL.py
+++ b/nrpy/infrastructures/superB/MoL.py
@@ -541,7 +541,7 @@ REAL *restrict {y_n_gridfunctions} = {gf_prefix}{y_n_gridfunctions};
     gf_aliases += "params_struct *restrict params = &griddata[grid].params;\n"
     if enable_rfm_precompute:
         gf_aliases += (
-            "const rfm_struct *restrict rfmstruct = &griddata[grid].rfmstruct;\n"
+            "const rfm_struct *restrict rfmstruct = griddata[grid].rfmstruct;\n"
         )
     else:
         gf_aliases += "REAL *restrict xx[3]; for(int ww=0;ww<3;ww++) xx[ww] = griddata[grid].xx[ww];\n"

--- a/nrpy/infrastructures/superB/diagnostics.py
+++ b/nrpy/infrastructures/superB/diagnostics.py
@@ -46,7 +46,7 @@ def register_CFunction_psi4_diagnostics_set_up() -> Union[None, pcg.NRPyEnv_type
   const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
   const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
   const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
-  
+
   const int psi4_spinweightm2_sph_harmonics_max_l = commondata->swm2sh_maximum_l_mode_to_compute;
 #define NUM_OF_R_EXTS 24
   const REAL list_of_R_exts[NUM_OF_R_EXTS] = {10.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0,  30.0,
@@ -112,7 +112,7 @@ def register_CFunction_psi4_diagnostics_set_up() -> Union[None, pcg.NRPyEnv_type
     diagnosticstruct->localsums_for_psi4_decomp = (REAL *restrict)malloc(sizeof(REAL) * size_psi4_decomp);
     diagnosticstruct->globalsums_for_psi4_decomp = (REAL *restrict)malloc(sizeof(REAL) * size_psi4_decomp);
     diagnosticstruct->length_localsums_for_psi4_decomp = size_psi4_decomp;
-    
+
     //
     // Case cylindrical-like grid
     //
@@ -320,7 +320,7 @@ def register_CFunction_psi4_diagnostics_set_up() -> Union[None, pcg.NRPyEnv_type
         free(xx_shell_Cart[which_R_ext]);
     }
     free(xx_shell_Cart);
-  } 
+  }
 """
     cfc.register_CFunction(
         includes=includes,
@@ -466,7 +466,7 @@ const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
 const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
 """
     body += r"""
-switch (which_output) {  
+switch (which_output) {
     """
     if enable_psi4_diagnostics:
         body += r"""
@@ -504,18 +504,18 @@ case OUTPUT_PSI4: {
 }"""
     if enable_L2norm_BSSN_constraints_diagnostics:
         body += r"""
-case OUTPUT_L2NORM_BSSN_CONSTRAINTS: {              
+case OUTPUT_L2NORM_BSSN_CONSTRAINTS: {
   const REAL integration_radius1 = 2;
   const REAL integration_radius2 = 1000;
-  // Compute local sums for l2-norm of the Hamiltonian and momentum constraints        
-  REAL localsums_HGF[2];    
+  // Compute local sums for l2-norm of the Hamiltonian and momentum constraints
+  REAL localsums_HGF[2];
   compute_L2_norm_of_gridfunction_between_r1_r2(commondata, griddata_chare, integration_radius1, integration_radius2, HGF, diagnostic_output_gfs,
                                                 localsums_HGF);
-                                                
-  REAL localsums_MSQUAREDGF[2];                                                                                                      
+
+  REAL localsums_MSQUAREDGF[2];
   compute_L2_norm_of_gridfunction_between_r1_r2(commondata, griddata_chare, integration_radius1, integration_radius2, MSQUAREDGF,
                                                 diagnostic_output_gfs, localsums_MSQUAREDGF);
-                                                
+
   localsums[0] = localsums_HGF[0];
   localsums[1] = localsums_HGF[1];
   localsums[2] = localsums_MSQUAREDGF[0];
@@ -536,15 +536,15 @@ default: {
             (num_diagnostic_1d_z_pts > 0) ||
             (num_diagnostic_2d_xy_pts > 0) ||
             (num_diagnostic_2d_yz_pts > 0);
-            
+
   // Compute constraints even if this chare does not contain any points on x or y axes or xy or yz plane
   // Contraints on the whole chare grid is used to compute l2-norm
   {
-    Ricci_eval(commondata, params_chare, &griddata_chare[grid].rfmstruct, y_n_gfs, auxevol_gfs);
-    constraints_eval(commondata, params_chare, &griddata_chare[grid].rfmstruct, y_n_gfs, auxevol_gfs, diagnostic_output_gfs);
+    Ricci_eval(commondata, params_chare, griddata_chare[grid].rfmstruct, y_n_gfs, auxevol_gfs);
+    constraints_eval(commondata, params_chare, griddata_chare[grid].rfmstruct, y_n_gfs, auxevol_gfs, diagnostic_output_gfs);
   }
   if (write_diagnostics) {
-  
+
     //  0D, 1D and 2D outputs
     if (which_output == OUTPUT_0D) {
         diagnostics_nearest_grid_center(commondata, params_chare, &griddata_chare[grid].gridfuncs);
@@ -899,7 +899,7 @@ static void lowlevel_decompose_psi4_into_swm2_modes(const int Nxx_plus_2NGHOSTS1
 
             src_gf_psi4i[idx] = diagnostic_output_gfs[IDX4GENERAL(PSI4_IMGF, i, i1, j, Nxx_plus_2NGHOSTS0chare, Nxx_plus_2NGHOSTS1chare,
                                                                   Nxx_plus_2NGHOSTS2chare)];
-                                  
+
           }
         }
         // Call the interpolation function

--- a/nrpy/infrastructures/superB/nrpyelliptic/conformally_flat_C_codegen_library.py
+++ b/nrpy/infrastructures/superB/nrpyelliptic/conformally_flat_C_codegen_library.py
@@ -267,7 +267,7 @@ def register_CFunction_diagnostics(
   const int nn = commondata->nn;
   const params_struct *restrict params = &griddata[grid].params;
   const params_struct *restrict params_chare = &griddata_chare[grid].params;
-  const rfm_struct *restrict rfmstruct_chare = &griddata_chare[grid].rfmstruct;
+  const rfm_struct *restrict rfmstruct_chare = griddata_chare[grid].rfmstruct;
   const charecomm_struct *restrict charecommstruct = &griddata_chare[grid].charecommstruct;
   const REAL *restrict y_n_gfs = griddata_chare[grid].gridfuncs.y_n_gfs;
   REAL *restrict auxevol_gfs = griddata_chare[grid].gridfuncs.auxevol_gfs;

--- a/nrpy/infrastructures/superB/numerical_grids.py
+++ b/nrpy/infrastructures/superB/numerical_grids.py
@@ -153,6 +153,7 @@ for(int grid=0; grid<commondata->NUMGRIDS; grid++) {
     if enable_rfm_precompute:
         body += r"""
 for(int grid=0; grid<commondata->NUMGRIDS; grid++) {
+  griddata_chare[grid].rfmstruct = (rfm_struct *)malloc(sizeof(rfm_struct));
   rfm_precompute_malloc(commondata, &griddata_chare[grid].params, griddata_chare[grid].rfmstruct);
   rfm_precompute_defines(commondata, &griddata_chare[grid].params, griddata_chare[grid].rfmstruct, griddata_chare[grid].xx);
 }

--- a/nrpy/infrastructures/superB/numerical_grids.py
+++ b/nrpy/infrastructures/superB/numerical_grids.py
@@ -153,8 +153,8 @@ for(int grid=0; grid<commondata->NUMGRIDS; grid++) {
     if enable_rfm_precompute:
         body += r"""
 for(int grid=0; grid<commondata->NUMGRIDS; grid++) {
-  rfm_precompute_malloc(commondata, &griddata_chare[grid].params, &griddata_chare[grid].rfmstruct);
-  rfm_precompute_defines(commondata, &griddata_chare[grid].params, &griddata_chare[grid].rfmstruct, griddata_chare[grid].xx);
+  rfm_precompute_malloc(commondata, &griddata_chare[grid].params, griddata_chare[grid].rfmstruct);
+  rfm_precompute_defines(commondata, &griddata_chare[grid].params, griddata_chare[grid].rfmstruct, griddata_chare[grid].xx);
 }
 """
     else:

--- a/nrpy/infrastructures/superB/superB/superB_pup.py
+++ b/nrpy/infrastructures/superB/superB/superB_pup.py
@@ -116,7 +116,7 @@ void pup_rfm_struct(PUP::er &p, rfm_struct *restrict rfm, const params_struct *r
                 size = "Nxx_plus_2NGHOSTS1"
             else:
                 size = "Nxx_plus_2NGHOSTS2"
-            prefunc += f"  PUParray(p, rfm.{var_name}, {size});\n"
+            prefunc += f"  PUParray(p, rfm->{var_name}, {size});\n"
     prefunc += """
 }
 """

--- a/nrpy/infrastructures/superB/superB/superB_pup.py
+++ b/nrpy/infrastructures/superB/superB/superB_pup.py
@@ -93,7 +93,7 @@ void pup_params_struct(PUP::er &p, params_struct &params) {
 
     prefunc += """
 // PUP routine for struct rfm_struct
-void pup_rfm_struct(PUP::er &p, rfm_struct &rfm, const params_struct *restrict params) {
+void pup_rfm_struct(PUP::er &p, rfm_struct *restrict rfm, const params_struct *restrict params) {
   const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
   const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
   const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
@@ -102,7 +102,7 @@ void pup_rfm_struct(PUP::er &p, rfm_struct &rfm, const params_struct *restrict p
     for CoordSystem in list_of_CoordSystems:
         rfm_precompute = ReferenceMetricPrecompute(CoordSystem)
         # Add memory allocation code
-        prefunc += rfm_precompute.rfm_struct__malloc.replace("rfmstruct->", "rfm.")
+        prefunc += rfm_precompute.rfm_struct__malloc
         prefunc += """}
         """
         # Add PUParray calls

--- a/nrpy/infrastructures/superB/superB/superB_pup.py
+++ b/nrpy/infrastructures/superB/superB/superB_pup.py
@@ -102,7 +102,7 @@ void pup_rfm_struct(PUP::er &p, rfm_struct *restrict rfm, const params_struct *r
     for CoordSystem in list_of_CoordSystems:
         rfm_precompute = ReferenceMetricPrecompute(CoordSystem)
         # Add memory allocation code
-        prefunc += rfm_precompute.rfm_struct__malloc
+        prefunc += rfm_precompute.rfm_struct__malloc.replace("rfmstruct->", "rfm->")
         prefunc += """}
         """
         # Add PUParray calls

--- a/nrpy/infrastructures/superB/timestepping_chare.py
+++ b/nrpy/infrastructures/superB/timestepping_chare.py
@@ -892,7 +892,7 @@ Timestepping::~Timestepping() {
     timestepping_free_memory_tmpBuffer(&griddata_chare[grid].nonlocalinnerbcstruct, &griddata_chare[grid].tmpBuffers);"""
     if enable_rfm_precompute:
         file_output_str += r"""
-    rfm_precompute_free(&commondata, &griddata_chare[grid].params, &griddata_chare[grid].rfmstruct);"""
+    rfm_precompute_free(&commondata, &griddata_chare[grid].params, griddata_chare[grid].rfmstruct);"""
     if enable_CurviBCs:
         file_output_str += r"""
     free(griddata[grid].bcstruct.inner_bc_array);

--- a/nrpy/infrastructures/superB/timestepping_chare.py
+++ b/nrpy/infrastructures/superB/timestepping_chare.py
@@ -892,7 +892,8 @@ Timestepping::~Timestepping() {
     timestepping_free_memory_tmpBuffer(&griddata_chare[grid].nonlocalinnerbcstruct, &griddata_chare[grid].tmpBuffers);"""
     if enable_rfm_precompute:
         file_output_str += r"""
-    rfm_precompute_free(&commondata, &griddata_chare[grid].params, griddata_chare[grid].rfmstruct);"""
+    rfm_precompute_free(&commondata, &griddata_chare[grid].params, griddata_chare[grid].rfmstruct);
+    free(griddata_chare[grid].rfmstruct);"""
     if enable_CurviBCs:
         file_output_str += r"""
     free(griddata[grid].bcstruct.inner_bc_array);


### PR DESCRIPTION
A limitation of the current `griddata` struct when attempting to generate CPU or GPU code is that the `rfmstruct` member is an object rather than a pointer.  Because of this, it is not possible to allocate this data on the device using, e.g. `cudaMalloc`.  

As a result, only the pointer members of `rfmstruct` can be allocated on the device which requires passing these pointers individually to a compute kernel rather than just passing the `rfmstruct`.  This makes the code generation more complex as the function arguments between CPU and GPU code differ significantly and it increases the register overhead since each of these pointers will have to be stored separately.

This PR resolves this by making `rfmstruct` a pointer and making the appropriate changes to the `BHaH` and `superB` infrastructures.