### PR TITLE
CUDA: Fix NRPyElliptic for CUDA intrinsics

### DIFF
--- a/nrpy/examples/nrpyelliptic_conformally_flat.py
+++ b/nrpy/examples/nrpyelliptic_conformally_flat.py
@@ -223,7 +223,7 @@ nrpyelliptic.initial_data.register_CFunction_initial_guess_all_points(
 # Generate function that calls functions to set variable wavespeed and all other AUXEVOL gridfunctions
 for CoordSystem in set_of_CoordSystems:
     nrpyelliptic.constant_source_terms_to_auxevol.register_CFunction_initialize_constant_auxevol(
-        CoordSystem, OMP_collapse=OMP_collapse
+        CoordSystem, OMP_collapse=OMP_collapse, enable_intrinsics=enable_intrinsics
     )
 
 numerical_grids_and_timestep.register_CFunctions(

--- a/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__Cartesian.cu
+++ b/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__Cartesian.cu
@@ -145,12 +145,9 @@ __global__ static void variable_wavespeed_gfs_all_points_gpu(const size_t stream
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = d_params[streamid].Nxx_plus_2NGHOSTS1;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = d_params[streamid].Nxx_plus_2NGHOSTS2;
 
-  const REAL NOCUDAinvdxx0 = d_params[streamid].invdxx0;
-  MAYBE_UNUSED const REAL_CUDA_ARRAY invdxx0 = ConstCUDA(NOCUDAinvdxx0);
-  const REAL NOCUDAinvdxx1 = d_params[streamid].invdxx1;
-  MAYBE_UNUSED const REAL_CUDA_ARRAY invdxx1 = ConstCUDA(NOCUDAinvdxx1);
-  const REAL NOCUDAinvdxx2 = d_params[streamid].invdxx2;
-  MAYBE_UNUSED const REAL_CUDA_ARRAY invdxx2 = ConstCUDA(NOCUDAinvdxx2);
+  MAYBE_UNUSED const REAL invdxx0 = d_params[streamid].invdxx0;
+  MAYBE_UNUSED const REAL invdxx1 = d_params[streamid].invdxx1;
+  MAYBE_UNUSED const REAL invdxx2 = d_params[streamid].invdxx2;
 
   MAYBE_UNUSED const int tid0 = blockIdx.x * blockDim.x + threadIdx.x;
   MAYBE_UNUSED const int tid1 = blockIdx.y * blockDim.y + threadIdx.y;

--- a/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__HoleySinhSpherical.cu
+++ b/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__HoleySinhSpherical.cu
@@ -163,12 +163,9 @@ __global__ static void variable_wavespeed_gfs_all_points_gpu(const size_t stream
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = d_params[streamid].Nxx_plus_2NGHOSTS1;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = d_params[streamid].Nxx_plus_2NGHOSTS2;
 
-  const REAL NOCUDAinvdxx0 = d_params[streamid].invdxx0;
-  MAYBE_UNUSED const REAL_CUDA_ARRAY invdxx0 = ConstCUDA(NOCUDAinvdxx0);
-  const REAL NOCUDAinvdxx1 = d_params[streamid].invdxx1;
-  MAYBE_UNUSED const REAL_CUDA_ARRAY invdxx1 = ConstCUDA(NOCUDAinvdxx1);
-  const REAL NOCUDAinvdxx2 = d_params[streamid].invdxx2;
-  MAYBE_UNUSED const REAL_CUDA_ARRAY invdxx2 = ConstCUDA(NOCUDAinvdxx2);
+  MAYBE_UNUSED const REAL invdxx0 = d_params[streamid].invdxx0;
+  MAYBE_UNUSED const REAL invdxx1 = d_params[streamid].invdxx1;
+  MAYBE_UNUSED const REAL invdxx2 = d_params[streamid].invdxx2;
 
   MAYBE_UNUSED const int tid0 = blockIdx.x * blockDim.x + threadIdx.x;
   MAYBE_UNUSED const int tid1 = blockIdx.y * blockDim.y + threadIdx.y;

--- a/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__SinhCylindricalv2n2.cu
+++ b/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__SinhCylindricalv2n2.cu
@@ -186,12 +186,9 @@ __global__ static void variable_wavespeed_gfs_all_points_gpu(const size_t stream
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = d_params[streamid].Nxx_plus_2NGHOSTS1;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = d_params[streamid].Nxx_plus_2NGHOSTS2;
 
-  const REAL NOCUDAinvdxx0 = d_params[streamid].invdxx0;
-  MAYBE_UNUSED const REAL_CUDA_ARRAY invdxx0 = ConstCUDA(NOCUDAinvdxx0);
-  const REAL NOCUDAinvdxx1 = d_params[streamid].invdxx1;
-  MAYBE_UNUSED const REAL_CUDA_ARRAY invdxx1 = ConstCUDA(NOCUDAinvdxx1);
-  const REAL NOCUDAinvdxx2 = d_params[streamid].invdxx2;
-  MAYBE_UNUSED const REAL_CUDA_ARRAY invdxx2 = ConstCUDA(NOCUDAinvdxx2);
+  MAYBE_UNUSED const REAL invdxx0 = d_params[streamid].invdxx0;
+  MAYBE_UNUSED const REAL invdxx1 = d_params[streamid].invdxx1;
+  MAYBE_UNUSED const REAL invdxx2 = d_params[streamid].invdxx2;
 
   MAYBE_UNUSED const int tid0 = blockIdx.x * blockDim.x + threadIdx.x;
   MAYBE_UNUSED const int tid1 = blockIdx.y * blockDim.y + threadIdx.y;

--- a/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__SinhSymTP.cu
+++ b/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__SinhSymTP.cu
@@ -169,12 +169,9 @@ __global__ static void variable_wavespeed_gfs_all_points_gpu(const size_t stream
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = d_params[streamid].Nxx_plus_2NGHOSTS1;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = d_params[streamid].Nxx_plus_2NGHOSTS2;
 
-  const REAL NOCUDAinvdxx0 = d_params[streamid].invdxx0;
-  MAYBE_UNUSED const REAL_CUDA_ARRAY invdxx0 = ConstCUDA(NOCUDAinvdxx0);
-  const REAL NOCUDAinvdxx1 = d_params[streamid].invdxx1;
-  MAYBE_UNUSED const REAL_CUDA_ARRAY invdxx1 = ConstCUDA(NOCUDAinvdxx1);
-  const REAL NOCUDAinvdxx2 = d_params[streamid].invdxx2;
-  MAYBE_UNUSED const REAL_CUDA_ARRAY invdxx2 = ConstCUDA(NOCUDAinvdxx2);
+  MAYBE_UNUSED const REAL invdxx0 = d_params[streamid].invdxx0;
+  MAYBE_UNUSED const REAL invdxx1 = d_params[streamid].invdxx1;
+  MAYBE_UNUSED const REAL invdxx2 = d_params[streamid].invdxx2;
 
   MAYBE_UNUSED const int tid0 = blockIdx.x * blockDim.x + threadIdx.x;
   MAYBE_UNUSED const int tid1 = blockIdx.y * blockDim.y + threadIdx.y;


### PR DESCRIPTION
The example was not generating correctly as the use of intrinsics was hard coded.  This has now been changed to be a user defined parameter, thereby resolving the codegen issues.