### PR TITLE
CUDA: Wavetoy

### DIFF
--- a/nrpy/examples/wave_equation_curvilinear.py
+++ b/nrpy/examples/wave_equation_curvilinear.py
@@ -5,6 +5,7 @@ Author: Zachariah B. Etienne
         zachetie **at** gmail **dot* com
 """
 
+import argparse
 import os
 
 #########################################################
@@ -13,12 +14,14 @@ import os
 import shutil
 
 import nrpy.helpers.parallel_codegen as pcg
+import nrpy.helpers.parallelization.cuda_utilities as cudautils
 import nrpy.infrastructures.BHaH.CurviBoundaryConditions.CurviBoundaryConditions as cbc
 import nrpy.infrastructures.BHaH.diagnostics.progress_indicator as progress
 import nrpy.params as par
 from nrpy.helpers.generic import copy_files
 from nrpy.infrastructures.BHaH import (
     BHaH_defines_h,
+    BHaH_device_defines_h,
     CodeParameters,
     Makefile_helpers,
     checkpointing,
@@ -33,7 +36,50 @@ from nrpy.infrastructures.BHaH import (
 )
 from nrpy.infrastructures.BHaH.MoLtimestepping import MoL_register_all
 
+parser = argparse.ArgumentParser(
+    description="NRPyElliptic Solver for Conformally Flat BBH initial data"
+)
+parser.add_argument(
+    "--parallelization",
+    type=str,
+    help="Parallelization strategy to use (e.g. openmp, cuda).",
+    default="openmp",
+)
+parser.add_argument(
+    "--floating_point_precision",
+    type=str,
+    help="Floating point precision (e.g. float, double).",
+    default="double",
+)
+parser.add_argument(
+    "--disable_intrinsics",
+    action="store_true",
+    help="Flag to disable hardware intrinsics",
+    default=False,
+)
+parser.add_argument(
+    "--disable_rfm_precompute",
+    action="store_true",
+    help="Flag to disable RFM precomputation.",
+    default=False,
+)
+args = parser.parse_args()
+
+# Code-generation-time parameters:
+fp_type = args.floating_point_precision.lower()
+parallelization = args.parallelization.lower()
+enable_intrinsics = not args.disable_intrinsics
+enable_rfm_precompute = not args.disable_rfm_precompute
+
+if parallelization not in ["openmp", "cuda"]:
+    raise ValueError(
+        f"Invalid parallelization strategy: {parallelization}. "
+        "Choose 'openmp' or 'cuda'."
+    )
+
 par.set_parval_from_str("Infrastructure", "BHaH")
+par.set_parval_from_str("parallelization", parallelization)
+par.set_parval_from_str("fp_type", fp_type)
 
 # Code-generation-time parameters:
 project_name = "curviwavetoy"
@@ -43,7 +89,13 @@ grid_physical_size = 10.0
 t_final = 0.8 * grid_physical_size
 default_diagnostics_output_every = 0.5
 default_checkpoint_every = 50.0
-CoordSystem = "Spherical"
+CoordSystem = "Cartesian"
+set_of_CoordSystems = {CoordSystem}
+list_of_grid_physical_sizes = []
+for CoordSystem in set_of_CoordSystems:
+    list_of_grid_physical_sizes.append(grid_physical_size)
+NUMGRIDS = len(set_of_CoordSystems)
+num_cuda_streams = NUMGRIDS
 # symmetry_axes will be set on any i such that Nxx[i] = 2 below.
 Nxx_dict = {
     "Spherical": [64, 2, 2],
@@ -60,11 +112,9 @@ if (
     par.set_parval_from_str("symmetry_axes", "12")
     OMP_collapse = 2  # about 2x faster
 
-enable_rfm_precompute = False
 MoL_method = "RK4"
 fd_order = 4
 radiation_BC_fd_order = 2
-enable_simd = False
 enable_KreissOliger_dissipation = False
 parallel_codegen_enable = True
 boundary_conditions_desc = "outgoing radiation"
@@ -77,29 +127,45 @@ shutil.rmtree(project_dir, ignore_errors=True)
 par.set_parval_from_str("parallel_codegen_enable", parallel_codegen_enable)
 par.set_parval_from_str("fd_order", fd_order)
 par.set_parval_from_str("CoordSystem_to_register_CodeParameters", CoordSystem)
+par.adjust_CodeParam_default("NUMGRIDS", NUMGRIDS)
 par.adjust_CodeParam_default("t_final", t_final)
-
 
 #########################################################
 # STEP 2: Declare core C functions & register each to
 #         cfc.CFunction_dict["function_name"]
-wave_equation.initial_data_exact_soln.register_CFunction_exact_solution_single_Cartesian_point(
-    WaveType=WaveType, default_sigma=default_sigma
+
+if parallelization == "cuda":
+    cudautils.register_CFunctions_HostDevice__operations()
+    cudautils.register_CFunction_find_global_minimum()
+    cudautils.register_CFunction_find_global_sum()
+
+wave_equation.initial_data_exact_soln.register_CFunction_initial_data_exact(
+    OMP_collapse=OMP_collapse, WaveType=WaveType, default_sigma=default_sigma
 )
 wave_equation.initial_data_exact_soln.register_CFunction_initial_data(
-    enable_checkpointing=True, OMP_collapse=OMP_collapse
+    enable_checkpointing=True,
 )
+
 numerical_grids_and_timestep.register_CFunctions(
-    set_of_CoordSystems={CoordSystem},
-    list_of_grid_physical_sizes=[grid_physical_size],
+    set_of_CoordSystems=set_of_CoordSystems,
+    list_of_grid_physical_sizes=list_of_grid_physical_sizes,
     Nxx_dict=Nxx_dict,
     enable_rfm_precompute=enable_rfm_precompute,
     enable_CurviBCs=True,
 )
-xx_tofrom_Cart.register_CFunction_xx_to_Cart(CoordSystem=CoordSystem)
+
+for CoordSystem in set_of_CoordSystems:
+    wave_equation.rhs_eval.register_CFunction_rhs_eval(
+        CoordSystem=CoordSystem,
+        enable_rfm_precompute=enable_rfm_precompute,
+        enable_intrinsics=enable_intrinsics,
+        enable_KreissOliger_dissipation=enable_KreissOliger_dissipation,
+        OMP_collapse=OMP_collapse,
+    )
+    xx_tofrom_Cart.register_CFunction_xx_to_Cart(CoordSystem=CoordSystem)
 
 wave_equation.diagnostics.register_CFunction_diagnostics(
-    set_of_CoordSystems={CoordSystem},
+    set_of_CoordSystems=set_of_CoordSystems,
     default_diagnostics_out_every=default_diagnostics_output_every,
     grid_center_filename_tuple=("out0d-conv_factor%.2f.txt", "convergence_factor"),
     axis_filename_tuple=(
@@ -113,22 +179,18 @@ wave_equation.diagnostics.register_CFunction_diagnostics(
     out_quantities_dict="default",
 )
 
-if enable_rfm_precompute:
-    rfm_precompute.register_CFunctions_rfm_precompute(set_of_CoordSystems={CoordSystem})
-wave_equation.rhs_eval.register_CFunction_rhs_eval(
-    CoordSystem=CoordSystem,
-    enable_rfm_precompute=enable_rfm_precompute,
-    enable_simd=enable_simd,
-    enable_KreissOliger_dissipation=enable_KreissOliger_dissipation,
-    OMP_collapse=OMP_collapse,
-)
-
 
 if __name__ == "__main__" and parallel_codegen_enable:
     pcg.do_parallel_codegen()
 
+if enable_rfm_precompute:
+    rfm_precompute.register_CFunctions_rfm_precompute(
+        set_of_CoordSystems=set_of_CoordSystems
+    )
+
 cbc.CurviBoundaryConditions_register_C_functions(
-    set_of_CoordSystems={CoordSystem}, radiation_BC_fd_order=radiation_BC_fd_order
+    set_of_CoordSystems=set_of_CoordSystems,
+    radiation_BC_fd_order=radiation_BC_fd_order,
 )
 rhs_string = """rhs_eval(commondata, params, rfmstruct,  RK_INPUT_GFS, RK_OUTPUT_GFS);
 if (strncmp(commondata->outer_bc_type, "radiation", 50) == 0)
@@ -146,7 +208,6 @@ MoL_register_all.register_CFunctions(
     enable_curviBCs=True,
 )
 checkpointing.register_CFunctions(default_checkpoint_every=default_checkpoint_every)
-
 progress.register_CFunction_progress_indicator()
 rfm_wrapper_functions.register_CFunctions_CoordSystem_wrapper_funcs()
 
@@ -163,35 +224,85 @@ cmdline_input_and_parfiles.generate_default_parfile(
 cmdline_input_and_parfiles.register_CFunction_cmdline_input_and_parfile_parser(
     project_name=project_name, cmdline_inputs=["convergence_factor"]
 )
+gpu_defines_filename = BHaH_device_defines_h.output_device_headers(
+    project_dir, num_streams=num_cuda_streams
+)
 BHaH_defines_h.output_BHaH_defines_h(
     project_dir=project_dir,
-    enable_intrinsics=enable_simd,
+    enable_intrinsics=enable_intrinsics,
+    intrinsics_header_lst=(
+        ["cuda_intrinsics.h"] if parallelization == "cuda" else ["simd_intrinsics.h"]
+    ),
     enable_rfm_precompute=enable_rfm_precompute,
     fin_NGHOSTS_add_one_for_upwinding_or_KO=enable_KreissOliger_dissipation,
+    DOUBLE_means="double" if fp_type == "float" else "REAL",
+    restrict_pointer_type="*" if parallelization == "cuda" else "*restrict",
+    supplemental_defines_dict=(
+        {
+            "C++/CUDA safe restrict": "#define restrict __restrict__",
+            "GPU Header": f'#include "{gpu_defines_filename}"',
+        }
+        if parallelization == "cuda"
+        else {}
+    ),
 )
+
+compute_griddata = "griddata_device" if parallelization in ["cuda"] else "griddata"
+write_checkpoint_call = f"write_checkpoint(&commondata, {compute_griddata});\n".replace(
+    compute_griddata,
+    (
+        f"griddata_host, {compute_griddata}"
+        if parallelization in ["cuda"]
+        else compute_griddata
+    ),
+)
+
 main_c.register_CFunction_main_c(
     initial_data_desc=WaveType,
-    pre_MoL_step_forward_in_time="write_checkpoint(&commondata, griddata);\n",
     MoL_method=MoL_method,
+    pre_MoL_step_forward_in_time=write_checkpoint_call,
     boundary_conditions_desc=boundary_conditions_desc,
 )
 griddata_commondata.register_CFunction_griddata_free(
     enable_rfm_precompute=enable_rfm_precompute, enable_CurviBCs=True
 )
 
-if enable_simd:
+if enable_intrinsics:
     copy_files(
         package="nrpy.helpers",
-        filenames_list=["simd_intrinsics.h"],
+        filenames_list=(
+            ["cuda_intrinsics.h"]
+            if parallelization == "cuda"
+            else ["simd_intrinsics.h"]
+        ),
         project_dir=project_dir,
         subdirectory="intrinsics",
     )
 
-Makefile_helpers.output_CFunctions_function_prototypes_and_construct_Makefile(
-    project_dir=project_dir,
-    project_name=project_name,
-    exec_or_library_name=project_name,
+cuda_makefiles_options = (
+    {
+        "CC": "nvcc",
+        "src_code_file_ext": "cu",
+        "compiler_opt_option": "nvcc",
+    }
+    if parallelization == "cuda"
+    else {}
 )
+if parallelization == "cuda":
+    Makefile_helpers.output_CFunctions_function_prototypes_and_construct_Makefile(
+        project_dir=project_dir,
+        project_name=project_name,
+        exec_or_library_name=project_name,
+        CC="nvcc",
+        src_code_file_ext="cu",
+        compiler_opt_option="nvcc",
+    )
+else:
+    Makefile_helpers.output_CFunctions_function_prototypes_and_construct_Makefile(
+        project_dir=project_dir,
+        project_name=project_name,
+        exec_or_library_name=project_name,
+    )
 print(
     f"Finished! Now go into project/{project_name} and type `make` to build, then ./{project_name} to run."
 )

--- a/nrpy/helpers/parallelization/gpu_kernel.py
+++ b/nrpy/helpers/parallelization/gpu_kernel.py
@@ -103,7 +103,7 @@ class GPU_Kernel:
             self.params_dict = {"streamid": "const size_t", **params_dict}
         self.name = c_function_name
         self.cfunc_type = f"{decorators} {cfunc_type}"
-        self.cuda_check_error = cuda_check_error
+        self.cuda_check_error = cuda_check_error and "__global__" in self.decorators
 
         self.CFunction: cfc.CFunction
         self.desc: str = f"Kernel: {self.name}.\n" + comments

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/CurviBoundaryConditions.py
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/CurviBoundaryConditions.py
@@ -851,7 +851,7 @@ for (int pt = tid0; pt < num_inner_boundary_points; pt+=stride0) {"""
         comments=comments,
         launch_dict={
             "blocks_per_grid": [
-                "(num_inner_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir"
+                "MAX(1U, (num_inner_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir)"
             ],
             "stream": "params->grid_idx % NUM_STREAMS",
         },
@@ -948,7 +948,7 @@ for (int which_gf = 0; which_gf < NUM_EVOL_GFS; which_gf++) {
         comments=comments,
         launch_dict={
             "blocks_per_grid": [
-                "(num_pure_outer_boundary_points + threads_in_x_dir -1) / threads_in_x_dir"
+                "MAX(1U, (num_pure_outer_boundary_points + threads_in_x_dir -1) / threads_in_x_dir)"
             ],
             "stream": "default",
         },
@@ -1584,7 +1584,7 @@ for (int idx2d = tid0; idx2d < num_pure_outer_boundary_points; idx2d+=stride0) {
         comments=comments,
         launch_dict={
             "blocks_per_grid": [
-                "(num_pure_outer_boundary_points + threads_in_x_dir -1) / threads_in_x_dir"
+                "MAX(1U, (num_pure_outer_boundary_points + threads_in_x_dir -1) / threads_in_x_dir)"
             ],
             "stream": "params->grid_idx % NUM_STREAMS",
         },
@@ -1828,7 +1828,6 @@ def CurviBoundaryConditions_register_C_functions(
     :param set_parity_on_aux: If True, set parity on auxiliary grid functions.
     :param set_parity_on_auxevol: If True, set parity on auxiliary evolution grid functions.
     """
-
     if par.parval_from_str("parallelization") == "cuda":
         register_CFunction_cpyHosttoDevice_bc_struct()
 

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/CurviBoundaryConditions.py
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/CurviBoundaryConditions.py
@@ -572,9 +572,6 @@ Step 2: Set up outer boundary structs bcstruct->outer_bc_array[which_gz][face][i
         ", bc_struct *restrict bcstruct_device" if parallelization in ["cuda"] else ""
     )
 
-    if parallelization == "cuda":
-        register_CFunction_cpyHosttoDevice_bc_struct()
-
     # Setup host-side struct to populate before copying to device
     body = r"""
   ////////////////////////////////////////
@@ -1831,6 +1828,10 @@ def CurviBoundaryConditions_register_C_functions(
     :param set_parity_on_aux: If True, set parity on auxiliary grid functions.
     :param set_parity_on_auxevol: If True, set parity on auxiliary evolution grid functions.
     """
+
+    if par.parval_from_str("parallelization") == "cuda":
+        register_CFunction_cpyHosttoDevice_bc_struct()
+
     for CoordSystem in set_of_CoordSystems:
         # Register C function to set up the boundary condition struct.
         register_CFunction_bcstruct_set_up(CoordSystem=CoordSystem)

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/CurviBoundaryConditions_apply_bcs_inner_only__cuda.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/CurviBoundaryConditions_apply_bcs_inner_only__cuda.cu
@@ -53,7 +53,7 @@ void apply_bcs_inner_only(const commondata_struct *restrict commondata, const pa
   const size_t threads_in_y_dir = BHAH_THREADS_IN_Y_DIR_CURVIBC_INNER;
   const size_t threads_in_z_dir = BHAH_THREADS_IN_Z_DIR_CURVIBC_INNER;
   dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
-  dim3 blocks_per_grid((num_inner_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+  dim3 blocks_per_grid(MAX(1U, (num_inner_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir), 1, 1);
   size_t sm = 0;
   size_t streamid = params->grid_idx % NUM_STREAMS;
   apply_bcs_inner_only_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, num_inner_boundary_points, inner_bc_array, gfs);

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/CurviBoundaryConditions_apply_bcs_outerextrap_and_inner__cuda.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/CurviBoundaryConditions_apply_bcs_outerextrap_and_inner__cuda.cu
@@ -59,7 +59,7 @@ static void apply_bcs_outerextrap_and_inner_only__launcher(const params_struct *
         const size_t threads_in_y_dir = BHAH_THREADS_IN_Y_DIR_CURVIBC_EXTRAP;
         const size_t threads_in_z_dir = BHAH_THREADS_IN_Z_DIR_CURVIBC_EXTRAP;
         dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
-        dim3 blocks_per_grid((num_pure_outer_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+        dim3 blocks_per_grid(MAX(1U, (num_pure_outer_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir), 1, 1);
         size_t sm = 0;
         size_t streamid = params->grid_idx % NUM_STREAMS;
         apply_bcs_outerextrap_and_inner_only_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/CurviBoundaryConditions_apply_bcs_outerradiation_and_inner__rfm__cuda__Cartesian.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/CurviBoundaryConditions_apply_bcs_outerradiation_and_inner__rfm__cuda__Cartesian.cu
@@ -341,7 +341,7 @@ static void apply_bcs_pure_only(const params_struct *restrict params, const bc_s
         const size_t threads_in_y_dir = BHAH_THREADS_IN_Y_DIR_CURVIBC_RAD_PURE;
         const size_t threads_in_z_dir = BHAH_THREADS_IN_Z_DIR_CURVIBC_RAD_PURE;
         dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
-        dim3 blocks_per_grid((num_pure_outer_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+        dim3 blocks_per_grid(MAX(1U, (num_pure_outer_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir), 1, 1);
         size_t sm = 0;
         size_t streamid = params->grid_idx % NUM_STREAMS;
         apply_bcs_pure_only_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, num_pure_outer_boundary_points, which_gz,

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/CurviBoundaryConditions_apply_bcs_outerradiation_and_inner__rfm__cuda__HoleySinhSpherical.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/CurviBoundaryConditions_apply_bcs_outerradiation_and_inner__rfm__cuda__HoleySinhSpherical.cu
@@ -232,7 +232,7 @@ static void apply_bcs_pure_only(const params_struct *restrict params, const bc_s
         const size_t threads_in_y_dir = BHAH_THREADS_IN_Y_DIR_CURVIBC_RAD_PURE;
         const size_t threads_in_z_dir = BHAH_THREADS_IN_Z_DIR_CURVIBC_RAD_PURE;
         dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
-        dim3 blocks_per_grid((num_pure_outer_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+        dim3 blocks_per_grid(MAX(1U, (num_pure_outer_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir), 1, 1);
         size_t sm = 0;
         size_t streamid = params->grid_idx % NUM_STREAMS;
         apply_bcs_pure_only_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, num_pure_outer_boundary_points, which_gz,

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/CurviBoundaryConditions_apply_bcs_outerradiation_and_inner__rfm__cuda__SinhCylindricalv2n2.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/CurviBoundaryConditions_apply_bcs_outerradiation_and_inner__rfm__cuda__SinhCylindricalv2n2.cu
@@ -311,7 +311,7 @@ static void apply_bcs_pure_only(const params_struct *restrict params, const bc_s
         const size_t threads_in_y_dir = BHAH_THREADS_IN_Y_DIR_CURVIBC_RAD_PURE;
         const size_t threads_in_z_dir = BHAH_THREADS_IN_Z_DIR_CURVIBC_RAD_PURE;
         dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
-        dim3 blocks_per_grid((num_pure_outer_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+        dim3 blocks_per_grid(MAX(1U, (num_pure_outer_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir), 1, 1);
         size_t sm = 0;
         size_t streamid = params->grid_idx % NUM_STREAMS;
         apply_bcs_pure_only_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, num_pure_outer_boundary_points, which_gz,

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/CurviBoundaryConditions_apply_bcs_outerradiation_and_inner__rfm__cuda__SinhSymTP.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/CurviBoundaryConditions_apply_bcs_outerradiation_and_inner__rfm__cuda__SinhSymTP.cu
@@ -302,7 +302,7 @@ static void apply_bcs_pure_only(const params_struct *restrict params, const bc_s
         const size_t threads_in_y_dir = BHAH_THREADS_IN_Y_DIR_CURVIBC_RAD_PURE;
         const size_t threads_in_z_dir = BHAH_THREADS_IN_Z_DIR_CURVIBC_RAD_PURE;
         dim3 threads_per_block(threads_in_x_dir, threads_in_y_dir, threads_in_z_dir);
-        dim3 blocks_per_grid((num_pure_outer_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir, 1, 1);
+        dim3 blocks_per_grid(MAX(1U, (num_pure_outer_boundary_points + threads_in_x_dir - 1) / threads_in_x_dir), 1, 1);
         size_t sm = 0;
         size_t streamid = params->grid_idx % NUM_STREAMS;
         apply_bcs_pure_only_gpu<<<blocks_per_grid, threads_per_block, sm, streams[streamid]>>>(streamid, num_pure_outer_boundary_points, which_gz,

--- a/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__Cartesian.cu
+++ b/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__Cartesian.cu
@@ -127,7 +127,6 @@ __global__ static void auxevol_gfs_all_points_gpu(const size_t streamid, const R
 
         auxevol_gfs_single_point_gpu(streamid, xx0, xx1, xx2, &in_gfs[IDX4(PSI_BACKGROUNDGF, i0, i1, i2)],
                                      &in_gfs[IDX4(ADD_TIMES_AUUGF, i0, i1, i2)]);
-        cudaCheckErrors(cudaKernel, "auxevol_gfs_single_point_gpu failure");
 
       } // END LOOP: for (int i0 = tid0; i0 < Nxx_plus_2NGHOSTS0; i0 += stride0)
     } // END LOOP: for (int i1 = tid1; i1 < Nxx_plus_2NGHOSTS1; i1 += stride1)

--- a/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__HoleySinhSpherical.cu
+++ b/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__HoleySinhSpherical.cu
@@ -145,7 +145,6 @@ __global__ static void auxevol_gfs_all_points_gpu(const size_t streamid, const R
 
         auxevol_gfs_single_point_gpu(streamid, xx0, xx1, xx2, &in_gfs[IDX4(PSI_BACKGROUNDGF, i0, i1, i2)],
                                      &in_gfs[IDX4(ADD_TIMES_AUUGF, i0, i1, i2)]);
-        cudaCheckErrors(cudaKernel, "auxevol_gfs_single_point_gpu failure");
 
       } // END LOOP: for (int i0 = tid0; i0 < Nxx_plus_2NGHOSTS0; i0 += stride0)
     } // END LOOP: for (int i1 = tid1; i1 < Nxx_plus_2NGHOSTS1; i1 += stride1)

--- a/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__SinhCylindricalv2n2.cu
+++ b/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__SinhCylindricalv2n2.cu
@@ -168,7 +168,6 @@ __global__ static void auxevol_gfs_all_points_gpu(const size_t streamid, const R
 
         auxevol_gfs_single_point_gpu(streamid, xx0, xx1, xx2, &in_gfs[IDX4(PSI_BACKGROUNDGF, i0, i1, i2)],
                                      &in_gfs[IDX4(ADD_TIMES_AUUGF, i0, i1, i2)]);
-        cudaCheckErrors(cudaKernel, "auxevol_gfs_single_point_gpu failure");
 
       } // END LOOP: for (int i0 = tid0; i0 < Nxx_plus_2NGHOSTS0; i0 += stride0)
     } // END LOOP: for (int i1 = tid1; i1 < Nxx_plus_2NGHOSTS1; i1 += stride1)

--- a/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__SinhSymTP.cu
+++ b/nrpy/infrastructures/BHaH/nrpyelliptic/tests/constant_source_terms_to_auxevol_initialize_constant_auxevol__cuda__SinhSymTP.cu
@@ -151,7 +151,6 @@ __global__ static void auxevol_gfs_all_points_gpu(const size_t streamid, const R
 
         auxevol_gfs_single_point_gpu(streamid, xx0, xx1, xx2, &in_gfs[IDX4(PSI_BACKGROUNDGF, i0, i1, i2)],
                                      &in_gfs[IDX4(ADD_TIMES_AUUGF, i0, i1, i2)]);
-        cudaCheckErrors(cudaKernel, "auxevol_gfs_single_point_gpu failure");
 
       } // END LOOP: for (int i0 = tid0; i0 < Nxx_plus_2NGHOSTS0; i0 += stride0)
     } // END LOOP: for (int i1 = tid1; i1 < Nxx_plus_2NGHOSTS1; i1 += stride1)

--- a/nrpy/infrastructures/BHaH/numerical_grids_and_timestep.py
+++ b/nrpy/infrastructures/BHaH/numerical_grids_and_timestep.py
@@ -570,7 +570,7 @@ def register_CFunction_numerical_grids_and_timestep(
     const bool set_xxmin_xxmax_to_defaults = true;
     int grid=0;
 """
-        for which_CoordSystem, CoordSystem in enumerate(set_of_CoordSystems):
+        for which_CoordSystem, CoordSystem in enumerate(sorted(set_of_CoordSystems)):
             body += f"""// In multipatch, gridname is a helpful alias indicating position of the patch. E.g., "lower {CoordSystem} patch"
     snprintf(griddata[grid].params.gridname, 100, "grid_{CoordSystem}");
 """

--- a/nrpy/infrastructures/BHaH/wave_equation/diagnostics.py
+++ b/nrpy/infrastructures/BHaH/wave_equation/diagnostics.py
@@ -7,7 +7,7 @@ Author: Zachariah B. Etienne
 
 from inspect import currentframe as cfr
 from types import FrameType as FT
-from typing import Dict, Set, Tuple, Union, cast
+from typing import Any, Dict, Set, Tuple, Union, cast
 
 import nrpy.c_function as cfc
 import nrpy.grid as gri
@@ -52,6 +52,7 @@ def register_CFunction_diagnostics(
         pcg.register_func_call(f"{__name__}.{cast(FT, cfr()).f_code.co_name}", locals())
         return None
 
+    parallelization = par.parval_from_str("parallelization")
     _ = par.CodeParameter(
         "REAL",
         __name__,
@@ -67,6 +68,11 @@ def register_CFunction_diagnostics(
     params = (
         "commondata_struct *restrict commondata, griddata_struct *restrict griddata"
     )
+    params += (
+        ", griddata_struct *restrict griddata_host"
+        if parallelization in ["cuda"]
+        else ""
+    )
 
     if "uuexact" not in gri.glb_gridfcs_dict:
         _ = gri.register_gridfunctions(
@@ -80,16 +86,38 @@ def register_CFunction_diagnostics(
     # fmt: off
     if out_quantities_dict == "default":
         out_quantities_dict = {
-            ("REAL", "log10ErelUU"): "log10(fabs((y_n_gfs[IDX4pt(UUGF, idx3)]-diagnostic_output_gfs[IDX4pt(UUEXACTGF, idx3)])/(diagnostic_output_gfs[IDX4pt(UUEXACTGF, idx3)] + 1e-16)) + 1e-16)",
-            ("REAL", "log10ErelVV"): "log10(fabs((y_n_gfs[IDX4pt(VVGF, idx3)]-diagnostic_output_gfs[IDX4pt(VVEXACTGF, idx3)])/(diagnostic_output_gfs[IDX4pt(VVEXACTGF, idx3)] + 1e-16)) + 1e-16)",
-            ("REAL", "exactUU"): "diagnostic_output_gfs[IDX4pt(UUEXACTGF, idx3)]",
+            ("REAL", "log10ErelUU"): "log10(fabs((y_n_gfs[IDX4pt(UUGF, idx3)]-diagnostic_output_gfs[IDX4pt(UUGF, idx3)])/(diagnostic_output_gfs[IDX4pt(UUGF, idx3)] + 1e-16)) + 1e-16)",
+            ("REAL", "log10ErelVV"): "log10(fabs((y_n_gfs[IDX4pt(VVGF, idx3)]-diagnostic_output_gfs[IDX4pt(VVGF, idx3)])/(diagnostic_output_gfs[IDX4pt(VVGF, idx3)] + 1e-16)) + 1e-16)",
+            ("REAL", "exactUU"): "diagnostic_output_gfs[IDX4pt(UUGF, idx3)]",
             ("REAL", "numUU"): "y_n_gfs[IDX4pt(UUGF, idx3)]",
-            ("REAL", "exactVV"): "diagnostic_output_gfs[IDX4pt(VVEXACTGF, idx3)]",
+            ("REAL", "exactVV"): "diagnostic_output_gfs[IDX4pt(VVGF, idx3)]",
             ("REAL", "numVV"): "y_n_gfs[IDX4pt(VVGF, idx3)]",
         }
     if not isinstance(out_quantities_dict, dict):
         raise TypeError(f"out_quantities_dict was initialized to {out_quantities_dict}, which is not a dictionary!")
     # fmt: on
+
+    out_quantities_gf_indexes_dict: Dict[str, Any] = {}
+
+    for gf_ptr in ["y_n_gfs", "diagnostic_output_gfs"]:
+        for v in out_quantities_dict.values():
+            parts = v.split(gf_ptr)
+            for tmp_str in parts[1:]:  # Skip part before gf_ptr
+                if "IDX4pt" in tmp_str and tmp_str and tmp_str[0] == "[":
+                    try:
+                        gf_name = (
+                            tmp_str.split("[")[1]
+                            .split(",")[0]
+                            .replace("IDX4pt(", "")
+                            .replace(")", "")
+                            .strip()
+                        )
+                        if gf_name not in out_quantities_gf_indexes_dict:
+                            out_quantities_gf_indexes_dict[gf_name] = []
+                        if gf_ptr not in out_quantities_gf_indexes_dict[gf_name]:
+                            out_quantities_gf_indexes_dict[gf_name].append(gf_ptr)
+                    except IndexError:
+                        continue  # Skip malformed strings
 
     for CoordSystem in set_of_CoordSystems:
         nearest012d.register_CFunction_diagnostics_nearest_grid_center(
@@ -113,43 +141,64 @@ def register_CFunction_diagnostics(
             )
     # fmt: on
 
-    body = r"""  const REAL currtime = commondata->time, currdt = commondata->dt, outevery = commondata->diagnostics_output_every;
+    host_griddata = "griddata_host" if parallelization == "cuda" else "griddata"
+    body = rf"""  const REAL currtime = commondata->time, currdt = commondata->dt, outevery = commondata->diagnostics_output_every;
   // Explanation of the if() below:
   // Step 1: round(currtime / outevery) rounds to the nearest integer multiple of currtime.
   // Step 2: Multiplying by outevery yields the exact time we should output again, t_out.
   // Step 3: If fabs(t_out - currtime) < 0.5 * currdt, then currtime is as close to t_out as possible!
-  if (fabs(round(currtime / outevery) * outevery - currtime) < 0.5 * currdt) {
-    for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {
+  if (fabs(round(currtime / outevery) * outevery - currtime) < 0.5 * currdt) {{
+    for (int grid = 0; grid < commondata->NUMGRIDS; grid++) {{
       // Unpack griddata struct:
       MAYBE_UNUSED const REAL *restrict y_n_gfs = griddata[grid].gridfuncs.y_n_gfs;
       REAL *restrict diagnostic_output_gfs = griddata[grid].gridfuncs.diagnostic_output_gfs;
       REAL *restrict xx[3];
       for (int ww = 0; ww < 3; ww++)
-        xx[ww] = griddata[grid].xx[ww];
+        xx[ww] = {host_griddata}[grid].xx[ww];
       const params_struct *restrict params = &griddata[grid].params;
-#include "set_CodeParameters.h"
+"""
 
-      LOOP_OMP("omp parallel for", i0, NGHOSTS, Nxx0 + NGHOSTS, i1, NGHOSTS, Nxx1 + NGHOSTS, i2, NGHOSTS, Nxx2 + NGHOSTS) {
-        REAL xCart[3];
-        REAL xOrig[3] = {xx[0][i0], xx[1][i1], xx[2][i2]};
-        xx_to_Cart(params, xOrig, xCart);
-        REAL *restrict uexact = &diagnostic_output_gfs[IDX4(UUEXACTGF, i0,i1,i2)];
-        REAL *restrict vexact = &diagnostic_output_gfs[IDX4(VVEXACTGF, i0,i1,i2)];
-        exact_solution_single_Cartesian_point(commondata, params, xCart[0], xCart[1], xCart[2], uexact, vexact);
-      }
+    if parallelization == "cuda":
+        body += rf"""
+    // This does not leverage async memory transfers using multiple streams at the moment
+    // given the current intent is one cuda stream per grid. This could be leveraged
+    // in the future by increasing NUM_STREAMS such that a diagnostic stream is included per grid
+    size_t streamid = params->grid_idx % NUM_STREAMS;
+    cpyHosttoDevice_params__constant(&griddata[grid].params, streamid);
+    REAL *restrict host_y_n_gfs = {host_griddata}[grid].gridfuncs.y_n_gfs;
+    REAL *restrict host_diagnostic_output_gfs = {host_griddata}[grid].gridfuncs.diagnostic_output_gfs;
 
+    // Copy solution to host
+"""
+        for idx, gfs in out_quantities_gf_indexes_dict.items():
+            for gf in gfs:
+                if gf == "y_n_gfs":
+                    body += f"    cpyDevicetoHost__gf(commondata, params, host_{gf}, {gf}, {idx}, {idx}, streamid);\n"
+    body += "\n initial_data_exact(commondata, params, griddata[grid].xx[0], griddata[grid].xx[1], griddata[grid].xx[2], diagnostic_output_gfs);\n"
+
+    if parallelization == "cuda":
+        body += "// Copy exact solution to host\n"
+        for idx, gfs in out_quantities_gf_indexes_dict.items():
+            for gf in gfs:
+                if gf == "diagnostic_output_gfs":
+                    body += f"    cpyDevicetoHost__gf(commondata, params, host_{gf}, {gf}, {idx}, {idx}, streamid);\n"
+        body += """
+        // Sync data before attempting to write to file
+        cudaStreamSynchronize(streams[streamid]);
+"""
+    body += rf"""
       // 0D output
-      diagnostics_nearest_grid_center(commondata, params, &griddata[grid].gridfuncs);
+      diagnostics_nearest_grid_center(commondata, params, &{host_griddata}[grid].gridfuncs);
 
       // 1D output
-      diagnostics_nearest_1d_y_axis(commondata, params, xx, &griddata[grid].gridfuncs);
-      diagnostics_nearest_1d_z_axis(commondata, params, xx, &griddata[grid].gridfuncs);
+      diagnostics_nearest_1d_y_axis(commondata, params, xx, &{host_griddata}[grid].gridfuncs);
+      diagnostics_nearest_1d_z_axis(commondata, params, xx, &{host_griddata}[grid].gridfuncs);
 
       // 2D output
-      diagnostics_nearest_2d_xy_plane(commondata, params, xx, &griddata[grid].gridfuncs);
-      diagnostics_nearest_2d_yz_plane(commondata, params, xx, &griddata[grid].gridfuncs);
-    }
-  }
+      diagnostics_nearest_2d_xy_plane(commondata, params, xx, &{host_griddata}[grid].gridfuncs);
+      diagnostics_nearest_2d_yz_plane(commondata, params, xx, &{host_griddata}[grid].gridfuncs);
+    }}
+  }}
 """
     if enable_progress_indicator:
         body += "progress_indicator(commondata, griddata);"

--- a/nrpy/infrastructures/BHaH/wave_equation/diagnostics.py
+++ b/nrpy/infrastructures/BHaH/wave_equation/diagnostics.py
@@ -142,7 +142,12 @@ def register_CFunction_diagnostics(
     # fmt: on
 
     host_griddata = "griddata_host" if parallelization == "cuda" else "griddata"
-    body = rf"""  const REAL currtime = commondata->time, currdt = commondata->dt, outevery = commondata->diagnostics_output_every;
+    body = (
+        "cpyHosttoDevice_commondata__constant(commondata);\n"
+        if parallelization in ["cuda"]
+        else ""
+    )
+    body += rf"""  const REAL currtime = commondata->time, currdt = commondata->dt, outevery = commondata->diagnostics_output_every;
   // Explanation of the if() below:
   // Step 1: round(currtime / outevery) rounds to the nearest integer multiple of currtime.
   // Step 2: Multiplying by outevery yields the exact time we should output again, t_out.

--- a/nrpy/infrastructures/BHaH/wave_equation/initial_data_exact_soln.py
+++ b/nrpy/infrastructures/BHaH/wave_equation/initial_data_exact_soln.py
@@ -194,6 +194,7 @@ def generate_CFunction_initial_data_compute(
         comments=desc,
         cfunc_type=cfunc_type,
         launchblock_with_braces=False,
+        thread_tiling_macro_suffix="WAVE_ID_EXACT"
     )
 
     for i in range(3):

--- a/nrpy/infrastructures/BHaH/wave_equation/initial_data_exact_soln.py
+++ b/nrpy/infrastructures/BHaH/wave_equation/initial_data_exact_soln.py
@@ -7,19 +7,209 @@ Author: Zachariah B. Etienne
 
 from inspect import currentframe as cfr
 from types import FrameType as FT
-from typing import Union, cast
+from typing import Tuple, Union, cast
 
 import nrpy.c_codegen as ccg
+import nrpy.helpers.parallelization.utilities as parallel_utils
 import nrpy.c_function as cfc
 import nrpy.grid as gri
 import nrpy.helpers.parallel_codegen as pcg
 import nrpy.infrastructures.BHaH.simple_loop as lp
+import nrpy.params as par
 from nrpy.equations.wave_equation.WaveEquation_Solutions_InitialData import (
     WaveEquation_solution_Cartesian,
 )
+from nrpy.helpers.expression_utils import (
+    generate_definition_header,
+    get_params_commondata_symbols_from_expr_list,
+)
 
 
-def register_CFunction_exact_solution_single_Cartesian_point(
+def generate_CFunction_exact_solution_single_Cartesian_point(
+    WaveType: str = "SphericalGaussian",
+    default_sigma: float = 3.0,
+    default_k0: float = 1.0,
+    default_k1: float = 1.0,
+    default_k2: float = 1.0,
+) -> Tuple[str, str]:
+    """
+    Register the C function for the exact solution at a single point.
+
+    :param WaveType: The type of wave: SphericalGaussian or PlaneWave
+    :param default_sigma: The default value for the Gaussian width (sigma).
+    :param default_k0: The default value for the plane wave wavenumber k in the x-direction.
+    :param default_k1: The default value for the plane wave wavenumber k in the y-direction.
+    :param default_k2: The default value for the plane wave wavenumber k in the z-direction.
+
+    :return: A tuple containing the kernel and launch body for the exact solution.
+    """
+
+    # Populate uu_ID, vv_ID
+    exactsoln = WaveEquation_solution_Cartesian(
+        WaveType=WaveType,
+        default_sigma=default_sigma,
+        default_k0=default_k0,
+        default_k1=default_k1,
+        default_k2=default_k2,
+    )
+
+    parallelization = par.parval_from_str("parallelization")
+
+    cfunc_decorators = "__device__" if parallelization in ["cuda"] else ""
+    desc = r"""Exact solution at a single Cartesian point (x, y, z) = (xCart0, xCart1, xCart2)."""
+    cfunc_type = "static void"
+    name = "exact_solution_single_Cartesian_point"
+
+    arg_dict_cuda = {
+        "params": "const params_struct *restrict",
+        "xCart0": "const REAL",
+        "xCart1": "const REAL",
+        "xCart2": "const REAL",
+        "exact_soln_UUGF": "REAL *restrict",
+        "exact_soln_VVGF": "REAL *restrict",
+    }
+
+    arg_dict_host = {
+        "commondata": "const commondata_struct *restrict",
+        **arg_dict_cuda,
+    }
+
+    expr_list = [exactsoln.uu_exactsoln, exactsoln.vv_exactsoln]
+
+    # Find symbols stored in params
+    param_symbols, commondata_symbols = get_params_commondata_symbols_from_expr_list(
+        expr_list, exclude=[f"xx{j}" for j in range(3)]
+    )
+
+    # Since xx_to_cart requires params as a host & device kernel we pass
+    # params struct as a pointer rather than use, e.g. constant CUDA
+    # memory
+    params_definitions = generate_definition_header(
+        param_symbols,
+        var_access=parallel_utils.get_params_access("openmp"),
+    )
+    commondata_definitions = generate_definition_header(
+        commondata_symbols,
+        var_access=parallel_utils.get_commondata_access(parallelization),
+    )
+
+    kernel_body = ccg.c_codegen(
+        expr_list,
+        ["*exact_soln_UUGF", "*exact_soln_VVGF"],
+        verbose=False,
+        include_braces=False,
+    )
+
+    kernel_body = f"{params_definitions}\n{commondata_definitions}\n\n{kernel_body}"
+
+    kernel, launch_body = parallel_utils.generate_kernel_and_launch_code(
+        name,
+        kernel_body.replace("SIMD", "CUDA" if parallelization == "cuda" else "SIMD"),
+        arg_dict_cuda,
+        arg_dict_host,
+        parallelization=parallelization,
+        comments=desc,
+        cfunc_type=cfunc_type,
+        launchblock_with_braces=False,
+        cfunc_decorators=cfunc_decorators,
+    )
+    return kernel, launch_body
+
+
+def generate_CFunction_initial_data_compute(
+    OMP_collapse: int,
+    WaveType: str = "SphericalGaussian",
+    default_sigma: float = 3.0,
+    default_k0: float = 1.0,
+    default_k1: float = 1.0,
+    default_k2: float = 1.0,
+) -> Tuple[str, str]:
+    """
+    Generate the initial data compute kernel for the wave equation with specific parameters.
+
+    :param OMP_collapse: Degree of OpenMP loop collapsing.
+    :param enable_checkpointing: Attempt to read from a checkpoint file before generating initial data.
+    :param WaveType: The type of wave: SphericalGaussian or PlaneWave
+    :param default_sigma: The default value for the Gaussian width (sigma).
+    :param default_k0: The default value for the plane wave wavenumber k in the x-direction.
+    :param default_k1: The default value for the plane wave wavenumber k in the y-direction.
+    :param default_k2: The default value for the plane wave wavenumber k in the z-direction.
+
+    :return: None if in registration phase, else the updated NRPy environment.
+    """
+    parallelization = par.parval_from_str("parallelization")
+
+    desc = r"""Set initial data to params.time==0 corresponds to the initial data."""
+    cfunc_type = "void"
+    name = "initial_data"
+    uu_gf_memaccess = gri.BHaHGridFunction.access_gf("uu")
+    vv_gf_memaccess = gri.BHaHGridFunction.access_gf("vv")
+    kernel_body = ""
+    host_griddata = "griddata_host" if parallelization in ["cuda"] else "griddata"
+
+    kernel_body += parallel_utils.get_loop_parameters(
+        parallelization
+    )
+
+    arg_dict_cuda = {
+        "params": "const params_struct *restrict",
+        "x0": "const REAL *restrict",
+        "x1": "const REAL *restrict",
+        "x2": "const REAL *restrict",
+        "in_gfs": "REAL *restrict",
+    }
+
+    arg_dict_host = {
+        "commondata": "const commondata_struct *restrict",
+        **arg_dict_cuda,
+    }
+
+    exact_singlept_kernel, exact_singlept_launch = generate_CFunction_exact_solution_single_Cartesian_point(
+        WaveType=WaveType,
+        default_sigma=default_sigma,
+        default_k0=default_k0,
+        default_k1=default_k1,
+        default_k2=default_k2,
+    )
+
+    loop_body=(
+        "REAL xCart[3]; REAL xOrig[3] = {xx0, xx1, xx2}; xx_to_Cart(params, xOrig, xCart);\n"
+        f"{exact_singlept_launch}"
+    )
+    for i in range(3):
+        loop_body = loop_body.replace(f"xCart{i}", f"xCart[{i}]")
+    loop_body = loop_body.replace("exact_soln_UUGF", f"&{uu_gf_memaccess}")
+    loop_body = loop_body.replace("exact_soln_VVGF", f"&{vv_gf_memaccess}")
+
+    kernel_body += lp.simple_loop(
+        loop_body=loop_body,
+        read_xxs=True,
+        loop_region="all points",
+        OMP_collapse=OMP_collapse,
+    )
+
+    kernel, launch_body = parallel_utils.generate_kernel_and_launch_code(
+        name,
+        kernel_body.replace("SIMD", "CUDA" if parallelization == "cuda" else "SIMD"),
+        arg_dict_cuda,
+        arg_dict_host,
+        parallelization=parallelization,
+        comments=desc,
+        cfunc_type=cfunc_type,
+        launchblock_with_braces=False,
+    )
+
+    for i in range(3):
+        kernel = kernel.replace(f"xx[{i}]", f"x{i}")
+
+    prefunc = exact_singlept_kernel + kernel
+
+    return prefunc, launch_body
+
+
+def register_CFunction_initial_data(
+    OMP_collapse: int,
+    enable_checkpointing: bool = False,
     WaveType: str = "SphericalGaussian",
     default_sigma: float = 3.0,
     default_k0: float = 1.0,
@@ -27,8 +217,10 @@ def register_CFunction_exact_solution_single_Cartesian_point(
     default_k2: float = 1.0,
 ) -> Union[None, pcg.NRPyEnv_type]:
     """
-    Register the C function for the exact solution at a single point.
+    Register the initial data function for the wave equation with specific parameters.
 
+    :param OMP_collapse: Degree of OpenMP loop collapsing.
+    :param enable_checkpointing: Attempt to read from a checkpoint file before generating initial data.
     :param WaveType: The type of wave: SphericalGaussian or PlaneWave
     :param default_sigma: The default value for the Gaussian width (sigma).
     :param default_k0: The default value for the plane wave wavenumber k in the x-direction.
@@ -40,9 +232,47 @@ def register_CFunction_exact_solution_single_Cartesian_point(
     if pcg.pcg_registration_phase():
         pcg.register_func_call(f"{__name__}.{cast(FT, cfr()).f_code.co_name}", locals())
         return None
+    parallelization = par.parval_from_str("parallelization")
+    includes = ["BHaH_defines.h", "BHaH_function_prototypes.h"]
 
-    # Populate uu_ID, vv_ID
-    exactsoln = WaveEquation_solution_Cartesian(
+    desc = r"""Set initial data to params.time==0 corresponds to the initial data."""
+    cfunc_type = "void"
+    name = "initial_data"
+    params = (
+        "commondata_struct *restrict commondata, griddata_struct *restrict griddata_host, griddata_struct *restrict griddata"
+        if parallelization in ["cuda"]
+        else "commondata_struct *restrict commondata, griddata_struct *restrict griddata"
+    )
+    body = ""
+    host_griddata = "griddata_host" if parallelization in ["cuda"] else "griddata"
+    if enable_checkpointing:
+        body += """// Attempt to read checkpoint file. If it doesn't exist, then continue. Otherwise return.
+if( read_checkpoint(commondata, griddata) ) return;
+""".replace(
+            "griddata",
+            f"{host_griddata}, griddata" if parallelization in ["cuda"] else "griddata",
+        )
+    if parallelization in ["cuda"]:
+        body += "cpyHosttoDevice_commondata__constant(commondata);\n"
+
+    body += r"""for(int grid=0; grid<commondata->NUMGRIDS; grid++) {
+  // Unpack griddata struct:
+"""
+    if parallelization in ["cuda"]:
+        body += "cpyHosttoDevice_params__constant(&griddata[grid].params, griddata[grid].params.grid_idx % NUM_STREAMS);\n"
+        body += "params_struct * params;\n"
+        body += "BHAH_MALLOC_DEVICE(params, sizeof(params_struct));\n"
+        body += "BHAH_MEMCPY_HOST_TO_DEVICE(params, &griddata[grid].params, sizeof(params_struct));\n"
+    else:
+        body += "params_struct *restrict params = &griddata[grid].params;\n"
+
+    body += "// Unpack griddata struct:\n"
+    for i in range(3):
+        body += f"REAL *restrict x{i} = griddata[grid].xx[{i}];\n"
+    body += "REAL *restrict in_gfs = griddata[grid].gridfuncs.y_n_gfs;\n"
+
+    prefunc, id_compute_launch = generate_CFunction_initial_data_compute(
+        OMP_collapse=OMP_collapse,
         WaveType=WaveType,
         default_sigma=default_sigma,
         default_k0=default_k0,
@@ -50,82 +280,12 @@ def register_CFunction_exact_solution_single_Cartesian_point(
         default_k2=default_k2,
     )
 
-    includes = ["BHaH_defines.h"]
-
-    desc = r"""Exact solution at a single Cartesian point (x, y, z) = (xCart0, xCart1, xCart2)."""
-    cfunc_type = "void"
-    name = "exact_solution_single_Cartesian_point"
-    params = r"""const commondata_struct *restrict commondata, const params_struct *restrict params,
-    const REAL xCart0, const REAL xCart1, const REAL xCart2,  REAL *restrict exact_soln_UUGF, REAL *restrict exact_soln_VVGF
-"""
-    body = ccg.c_codegen(
-        [exactsoln.uu_exactsoln, exactsoln.vv_exactsoln],
-        ["*exact_soln_UUGF", "*exact_soln_VVGF"],
-        verbose=False,
-        include_braces=False,
-    )
-    cfc.register_CFunction(
-        includes=includes,
-        desc=desc,
-        cfunc_type=cfunc_type,
-        name=name,
-        params=params,
-        include_CodeParameters_h=True,
-        body=body,
-    )
-    return cast(pcg.NRPyEnv_type, pcg.NRPyEnv())
-
-
-def register_CFunction_initial_data(
-    OMP_collapse: int,
-    enable_checkpointing: bool = False,
-) -> Union[None, pcg.NRPyEnv_type]:
-    """
-    Register the initial data function for the wave equation with specific parameters.
-
-    :param OMP_collapse: Degree of OpenMP loop collapsing.
-    :param enable_checkpointing: Attempt to read from a checkpoint file before generating initial data.
-
-    :return: None if in registration phase, else the updated NRPy environment.
-    """
-    if pcg.pcg_registration_phase():
-        pcg.register_func_call(f"{__name__}.{cast(FT, cfr()).f_code.co_name}", locals())
-        return None
-    includes = ["BHaH_defines.h", "BHaH_function_prototypes.h"]
-
-    desc = r"""Set initial data to params.time==0 corresponds to the initial data."""
-    cfunc_type = "void"
-    name = "initial_data"
-    params = (
-        "commondata_struct *restrict commondata, griddata_struct *restrict griddata"
-    )
-    uu_gf_memaccess = gri.BHaHGridFunction.access_gf("uu")
-    vv_gf_memaccess = gri.BHaHGridFunction.access_gf("vv")
-    body = ""
-    if enable_checkpointing:
-        body += """// Attempt to read checkpoint file. If it doesn't exist, then continue. Otherwise return.
-if( read_checkpoint(commondata, griddata) ) return;
-"""
-    body += r"""for(int grid=0; grid<commondata->NUMGRIDS; grid++) {
-  // Unpack griddata struct:
-  params_struct *restrict params = &griddata[grid].params;
-#include "set_CodeParameters.h"
-  REAL *restrict xx[3];
-  for (int ww = 0; ww < 3; ww++)
-    xx[ww] = griddata[grid].xx[ww];
-  REAL *restrict in_gfs = griddata[grid].gridfuncs.y_n_gfs;
-"""
-    body += lp.simple_loop(
-        loop_body="REAL xCart[3]; REAL xOrig[3] = {xx[0][i0], xx[1][i1], xx[2][i2]}; xx_to_Cart(params, xOrig, xCart);\n"
-        "exact_solution_single_Cartesian_point(commondata, params, xCart[0], xCart[1], xCart[2],"
-        f"&{uu_gf_memaccess},"
-        f"&{vv_gf_memaccess});",
-        read_xxs=True,
-        loop_region="all points",
-        OMP_collapse=OMP_collapse,
-    )
+    body+= id_compute_launch
+    if parallelization in ["cuda"]:
+        body += "BHAH_FREE_DEVICE(params);\n"
     body += "}\n"
     cfc.register_CFunction(
+        prefunc=prefunc,
         includes=includes,
         desc=desc,
         cfunc_type=cfunc_type,

--- a/nrpy/infrastructures/BHaH/wave_equation/rhs_eval.py
+++ b/nrpy/infrastructures/BHaH/wave_equation/rhs_eval.py
@@ -104,7 +104,9 @@ def register_CFunction_rhs_eval(
         var_access=parallel_utils.get_params_access(parallelization),
     )
 
-    kernel_body = parallel_utils.get_loop_parameters(parallelization)
+    kernel_body = parallel_utils.get_loop_parameters(
+        parallelization, enable_intrinsics=enable_intrinsics
+    )
 
     if enable_intrinsics:
         for symbol in commondata_symbols:
@@ -167,7 +169,7 @@ def register_CFunction_rhs_eval(
         arg_dict_host,
         parallelization=parallelization,
         comments=desc,
-        cfunc_type=cfunc_type,
+        cfunc_type=f"static {cfunc_type}",
         launchblock_with_braces=False,
         thread_tiling_macro_suffix="WAVE_RHS",
     )

--- a/nrpy/infrastructures/BHaH/wave_equation/rhs_eval.py
+++ b/nrpy/infrastructures/BHaH/wave_equation/rhs_eval.py
@@ -14,6 +14,7 @@ import nrpy.c_codegen as ccg
 import nrpy.c_function as cfc
 import nrpy.grid as gri
 import nrpy.helpers.parallel_codegen as pcg
+import nrpy.helpers.parallelization.utilities as parallel_utils
 import nrpy.indexedexp as ixp
 import nrpy.infrastructures.BHaH.simple_loop as lp
 import nrpy.params as par
@@ -21,12 +22,16 @@ import nrpy.reference_metric as refmetric
 from nrpy.equations.wave_equation.WaveEquationCurvilinear_RHSs import (
     WaveEquationCurvilinear_RHSs,
 )
+from nrpy.helpers.expression_utils import (
+    generate_definition_header,
+    get_params_commondata_symbols_from_expr_list,
+)
 
 
 def register_CFunction_rhs_eval(
     CoordSystem: str,
     enable_rfm_precompute: bool,
-    enable_simd: bool,
+    enable_intrinsics: bool,
     enable_KreissOliger_dissipation: bool,
     OMP_collapse: int,
 ) -> Union[None, pcg.NRPyEnv_type]:
@@ -38,7 +43,7 @@ def register_CFunction_rhs_eval(
 
     :param CoordSystem: The coordinate system.
     :param enable_rfm_precompute: Whether to enable reference metric precomputation.
-    :param enable_simd: Whether to enable SIMD.
+    :param enable_intrinsics: Whether to enable hardware intrinsics, e.g. SIMD.
     :param enable_KreissOliger_dissipation: Whether to enable Kreiss-Oliger dissipation, to damp high-frequency noise.
     :param OMP_collapse: Level of OpenMP loop collapsing.
 
@@ -48,9 +53,16 @@ def register_CFunction_rhs_eval(
         pcg.register_func_call(f"{__name__}.{cast(FT, cfr()).f_code.co_name}", locals())
         return None
 
+    parallelization = par.parval_from_str("parallelization")
     includes = ["BHaH_defines.h"]
-    if enable_simd:
-        includes += [str(Path("intrinsics") / "simd_intrinsics.h")]
+    if enable_intrinsics:
+        includes += [
+            str(
+                Path("intrinsics") / "cuda_intrinsics.h"
+                if parallelization == "cuda"
+                else Path("intrinsics") / "simd_intrinsics.h"
+            )
+        ]
     desc = r"""Set RHSs for wave equation."""
     cfunc_type = "void"
     name = "rhs_eval"
@@ -81,33 +93,106 @@ def register_CFunction_rhs_eval(
             rhs.vv_rhs += (
                 diss_strength * vv_dKOD[k] * rfm.ReU[k]
             )  # ReU[k] = 1/scalefactor_orthog_funcform[k]
-    body = lp.simple_loop(
+    expr_list = [rhs.uu_rhs, rhs.vv_rhs]
+
+    # Find symbols stored in params
+    param_symbols, commondata_symbols = get_params_commondata_symbols_from_expr_list(
+        expr_list, exclude=[f"xx{j}" for j in range(3)]
+    )
+    params_definitions = generate_definition_header(
+        param_symbols,
+        var_access=parallel_utils.get_params_access(parallelization),
+    )
+
+    kernel_body = parallel_utils.get_loop_parameters(parallelization)
+
+    if enable_intrinsics:
+        for symbol in commondata_symbols:
+            kernel_body += f"MAYBE_UNUSED const REAL_SIMD_ARRAY {symbol} = ConstSIMD(NOSIMD{symbol});\n"
+
+    kernel_body += f"{params_definitions}\n"
+    kernel_body += lp.simple_loop(
         loop_body=ccg.c_codegen(
-            [rhs.uu_rhs, rhs.vv_rhs],
+            expr_list,
             [
                 gri.BHaHGridFunction.access_gf("uu", gf_array_name="rhs_gfs"),
                 gri.BHaHGridFunction.access_gf("vv", gf_array_name="rhs_gfs"),
             ],
             enable_fd_codegen=True,
-            enable_simd=enable_simd,
+            enable_simd=enable_intrinsics,
         ),
         loop_region="interior",
-        enable_intrinsics=enable_simd,
+        enable_intrinsics=enable_intrinsics,
         CoordSystem=CoordSystem,
         enable_rfm_precompute=enable_rfm_precompute,
         read_xxs=not enable_rfm_precompute,
         OMP_collapse=OMP_collapse,
     )
 
+    arg_dict_cuda = {
+        "in_gfs": "const REAL *restrict",
+        "rhs_gfs": "REAL *restrict",
+    }
+
+    if enable_rfm_precompute:
+        arg_dict_cuda = {
+            "rfmstruct": "const rfm_struct *restrict",
+            **arg_dict_cuda,
+        }
+    else:
+        arg_dict_cuda = {
+            "x0": "const REAL *restrict",
+            "x1": "const REAL *restrict",
+            "x2": "const REAL *restrict",
+            **arg_dict_cuda,
+        }
+
+    arg_dict_cuda = {
+        **arg_dict_cuda,
+        **{
+            f"NOCUDA{k}" if enable_intrinsics else k: "const REAL"
+            for k in commondata_symbols
+        },
+    }
+
+    arg_dict_host = {
+        "params": "const params_struct *restrict",
+        **{k.replace("CUDA", "SIMD"): v for k, v in arg_dict_cuda.items()},
+    }
+
+    prefunc, launch_body = parallel_utils.generate_kernel_and_launch_code(
+        name,
+        kernel_body.replace("SIMD", "CUDA" if parallelization == "cuda" else "SIMD"),
+        arg_dict_cuda,
+        arg_dict_host,
+        parallelization=parallelization,
+        comments=desc,
+        cfunc_type=cfunc_type,
+        launchblock_with_braces=False,
+        thread_tiling_macro_suffix="WAVE_RHS",
+    )
+
+    for symbol in commondata_symbols:
+        tmp_sym = (
+            f"NOCUDA{symbol}"
+            if parallelization == "cuda" and enable_intrinsics
+            else (
+                f"NOSIMD{symbol}"
+                if enable_intrinsics
+                else symbol if enable_intrinsics else symbol
+            )
+        )
+        launch_body = launch_body.replace(tmp_sym, f"commondata->{symbol}")
+
     cfc.register_CFunction(
-        include_CodeParameters_h=True,
+        prefunc=prefunc,
         includes=includes,
         desc=desc,
         cfunc_type=cfunc_type,
         CoordSystem_for_wrapper_func=CoordSystem,
         name=name,
         params=params,
-        body=body,
-        enable_simd=enable_simd,
+        body=launch_body,
+        enable_simd=enable_intrinsics,
     )
     return cast(pcg.NRPyEnv_type, pcg.NRPyEnv())


### PR DESCRIPTION
The following PR consists of a significant refactor to the `wavetoy` example as well as making it `CUDA` aware.

Significant changes from the original code:
* The `initial_data` routines have seen significant changes to their structure and interface with the introduction of `initial_data_exact`.  This enables an exact solution to be computed based on an input grid and stored in a user provided array.
* With the introduction of `initial_data_exact`, `diagnostics` can now call `initial_data_exact` using `diagnostic_output_gfs` rather than needing to duplicate this code within diagnostics to compute the exact solution for comparison against.
* `wave_equation_curvilinear` has been refactored to be consistent with `wave_equation_multicoord_wavetoy`
* Naturally all aspects of the `wave_equation` components and the curvilinear examples have been made compatible with the `CUDA` codegen