### PR TITLE
Add higher order mode QNM frequencies to SEOBNRv5_aligned_spin_coefficients.py

### DIFF
--- a/nrpy/infrastructures/BHaH/seobnr/SEOBNRv5_aligned_spin_coefficients.py
+++ b/nrpy/infrastructures/BHaH/seobnr/SEOBNRv5_aligned_spin_coefficients.py
@@ -662,7 +662,7 @@ if (spline == NULL){
 }
 gsl_interp_accel *acc = gsl_interp_accel_alloc();
 if (acc == NULL){
-  fprintf(stderr,"Error: in SEOBNRv5_aligned_spin_coefficients(), gsl_interp_acc_alloc failed to initialize\\n");
+  fprintf(stderr,"Error: in SEOBNRv5_aligned_spin_coefficients(), gsl_interp_accel_alloc failed to initialize\\n");
   gsl_spline_free(spline); // Clean up the first allocation
   exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
Added higher order mode QNM frequency values, with interp = False. Replaced prior interpolated results for 2,2 mode.

Values generated using
qnm version =  0.4.4
numba = 0.63.0
numpy 2.0.2