### PR TITLE
perf(bcs): precompute outer boundary geometry in bcstruct_set_up

### DIFF
--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/BHaH_defines.py
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/BHaH_defines.py
@@ -170,6 +170,12 @@ typedef struct __outerpt_bc_struct__ {
   //                               FACEX0,FACEX1,FACEX2 =  0,-1, 0 if on the i1=i1max face,
   //                               FACEX0,FACEX1,FACEX2 =  0, 0,+1 if on the i2=i2min face, or
   //                               FACEX0,FACEX1,FACEX2 =  0, 0,-1 if on the i2=i2max face,
+  REAL r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r;  // r and dx^i/dr at this outer
+  //                               boundary point. Grid-static, so precomputed once in bcstruct_set_up()
+  //                               instead of being recomputed for every gridfunction on every RK substep.
+  REAL r_int, partial_x0_partial_r_int, partial_x1_partial_r_int, partial_x2_partial_r_int;  // the same
+  //                               quantities at the nearest interior neighbour, (i0,i1,i2)+(FACEX0,FACEX1,FACEX2);
+  //                               "_int" abbreviates interior, not integer.
 } outerpt_bc_struct;
 
 typedef struct __bc_info_struct__ {

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/apply_bcs_outerradiation_and_inner.py
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/apply_bcs_outerradiation_and_inner.py
@@ -45,32 +45,26 @@ from nrpy.validate_expressions.validate_expressions import check_zero
 # r_and_partial_xi_partial_r_derivs(): Compute r(x0,x1,x2) and dx^i / dr
 def setup_Cfunction_r_and_partial_xi_partial_r_derivs(
     CoordSystem: str,
-    cfunc_decorators: str = "",
 ) -> str:
     """
     Generate C code to compute the radial coordinate r(x0, x1, x2) and its derivatives.
 
     Compute the radial coordinate r(x0, x1, x2) and its partial derivatives
-    partial x^i / partial r for a given coordinate system.
+    partial x^i / partial r for a given coordinate system. This helper is called
+    only from bcstruct_set_up(), which is host code in all parallelizations, so
+    it unconditionally takes a params_struct.
 
     :param CoordSystem: The coordinate system for which to compute r and its derivatives.
-    :param cfunc_decorators: Optional decorators for CFunctions, e.g. CUDA identifiers, templates
     :return: A string containing the generated C code for the function.
     """
     desc = "Compute r(xx0,xx1,xx2) and partial_r x^i."
     cfunc_type = "static inline void"
     name = "r_and_partial_xi_partial_r_derivs"
-    parallelization = par.parval_from_str("parallelization")
     params = (
-        "const size_t streamid, const REAL xx0,const REAL xx1,const REAL xx2, REAL *r,"
-        "REAL *partial_x0_partial_r,REAL *partial_x1_partial_r,REAL *partial_x2_partial_r"
-        if parallelization == "cuda"
-        else "const params_struct *restrict params, const REAL xx0,const REAL xx1,const REAL xx2, REAL *r,"
+        "const params_struct *restrict params, const REAL xx0,const REAL xx1,const REAL xx2, REAL *r,"
         "REAL *partial_x0_partial_r,REAL *partial_x1_partial_r,REAL *partial_x2_partial_r"
     )
     body = ""
-    if parallelization == "cuda" and "device" not in cfunc_decorators:
-        cfunc_decorators += " __device__"
 
     rfm = refmetric.reference_metric[CoordSystem]
     # sp.simplify(expr) is too slow here for SinhCylindrical
@@ -112,7 +106,6 @@ def setup_Cfunction_r_and_partial_xi_partial_r_derivs(
         params=params,
         include_CodeParameters_h=False,
         body=body,
-        cfunc_decorators=cfunc_decorators,
     )
     return cf.full_function
 
@@ -395,10 +388,7 @@ def setup_Cfunction_radiation_bcs(
                 radiation_BC_fd_order=radiation_BC_fd_order,
                 rational_const_alias=rational_const_alias,
             )
-    prefunc += setup_Cfunction_r_and_partial_xi_partial_r_derivs(
-        CoordSystem=CoordSystem,
-        cfunc_decorators=cfunc_decorators,
-    )
+
     prefunc += setup_Cfunction_compute_partial_r_f(
         CoordSystem=CoordSystem,
         cfunc_decorators=cfunc_decorators,
@@ -413,14 +403,18 @@ def setup_Cfunction_radiation_bcs(
         const REAL *restrict gfs, REAL *restrict gfs_rhss,
         const int which_gf, const REAL gf_wavespeed, const REAL gf_f_infinity,
         const int dest_i0,const int dest_i1,const int dest_i2,
-        const short FACEi0,const short FACEi1,const short FACEi2"""
+        const short FACEi0,const short FACEi1,const short FACEi2,
+        const REAL r, const REAL partial_x0_partial_r, const REAL partial_x1_partial_r, const REAL partial_x2_partial_r,
+        const REAL r_int, const REAL partial_x0_partial_r_int, const REAL partial_x1_partial_r_int, const REAL partial_x2_partial_r_int"""
         if parallelization == "cuda"
         else """const params_struct *restrict params,
     REAL *restrict xx[3],
     const REAL *restrict gfs, REAL *restrict gfs_rhss,
     const int which_gf, const REAL gf_wavespeed, const REAL gf_f_infinity,
     const int dest_i0,const int dest_i1,const int dest_i2,
-    const short FACEi0,const short FACEi1,const short FACEi2"""
+    const short FACEi0,const short FACEi1,const short FACEi2,
+    const REAL r, const REAL partial_x0_partial_r, const REAL partial_x1_partial_r, const REAL partial_x2_partial_r,
+    const REAL r_int, const REAL partial_x0_partial_r_int, const REAL partial_x1_partial_r_int, const REAL partial_x2_partial_r_int"""
     )
 
     param_access = parallel_utils.get_params_access(parallelization)
@@ -428,12 +422,6 @@ def setup_Cfunction_radiation_bcs(
     body += f"{parallel_utils.get_loop_parameters(parallelization)}\n"
     body += r"""// Nearest "interior" neighbor of this gridpoint, based on current face
 const int dest_i0_int=dest_i0+1*FACEi0, dest_i1_int=dest_i1+1*FACEi1, dest_i2_int=dest_i2+1*FACEi2;
-REAL r, partial_x0_partial_r,partial_x1_partial_r,partial_x2_partial_r;
-REAL r_int, partial_x0_partial_r_int,partial_x1_partial_r_int,partial_x2_partial_r_int;
-r_and_partial_xi_partial_r_derivs(params,xx[0][dest_i0],xx[1][dest_i1],xx[2][dest_i2],
-                                  &r, &partial_x0_partial_r, &partial_x1_partial_r,  &partial_x2_partial_r);
-r_and_partial_xi_partial_r_derivs(params, xx[0][dest_i0_int], xx[1][dest_i1_int], xx[2][dest_i2_int],
-                                  &r_int, &partial_x0_partial_r_int, &partial_x1_partial_r_int, &partial_x2_partial_r_int);
 const REAL partial_r_f     = compute_partial_r_f(params,xx,gfs, which_gf,dest_i0,    dest_i1,    dest_i2,
                                                  FACEi0,FACEi1,FACEi2,
                                                  partial_x0_partial_r    ,partial_x1_partial_r    ,partial_x2_partial_r);
@@ -526,11 +514,21 @@ for (int idx2d = tid0; idx2d < num_pure_outer_boundary_points; idx2d+=stride0) {
     const short FACEX2 = pure_outer_bc_array[idx2d].FACEX2;
     const int idx3 = IDX3(i0,i1,i2);
     REAL* xx[3] = {x0, x1, x2};
+    const REAL r = pure_outer_bc_array[idx2d].r;
+    const REAL partial_x0_partial_r = pure_outer_bc_array[idx2d].partial_x0_partial_r;
+    const REAL partial_x1_partial_r = pure_outer_bc_array[idx2d].partial_x1_partial_r;
+    const REAL partial_x2_partial_r = pure_outer_bc_array[idx2d].partial_x2_partial_r;
+    const REAL r_int = pure_outer_bc_array[idx2d].r_int;
+    const REAL partial_x0_partial_r_int = pure_outer_bc_array[idx2d].partial_x0_partial_r_int;
+    const REAL partial_x1_partial_r_int = pure_outer_bc_array[idx2d].partial_x1_partial_r_int;
+    const REAL partial_x2_partial_r_int = pure_outer_bc_array[idx2d].partial_x2_partial_r_int;
     for (int which_gf = 0; which_gf < NUM_EVOL_GFS; which_gf++) {
         // *** Apply radiation BCs to all outer boundary points. ***
         rhs_gfs[IDX4pt(which_gf, idx3)] = radiation_bcs(params, xx, gfs, rhs_gfs, which_gf,
                                                         custom_wavespeed[which_gf], custom_f_infinity[which_gf],
-                                                        i0,i1,i2, FACEX0,FACEX1,FACEX2);
+                                                        i0,i1,i2, FACEX0,FACEX1,FACEX2,
+                                                        r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r,
+                                                        r_int, partial_x0_partial_r_int, partial_x1_partial_r_int, partial_x2_partial_r_int);
     }
   }
 """.replace("params,", "streamid," if parallelization == "cuda" else "params,").replace(

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/bcstruct_set_up.py
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/bcstruct_set_up.py
@@ -13,6 +13,11 @@ conditions on a curvilinear grid. The setup process involves:
     source grid point and the tensor-type-specific parity transformations.
 3.  **Organizing outer boundary data:** It catalogs outer boundary points by face
     and layer to facilitate sequential application.
+4.  **Precomputing outer boundary geometry:** For each outer boundary point it
+    stores the radius and dx^i/dr, both at the point and at its nearest interior
+    neighbour. These depend only on the grid, so computing them here spares the
+    radiation boundary condition from recomputing them for every gridfunction on
+    every Runge-Kutta substep.
 
 This pre-computation allows for efficient application of boundary conditions
 at runtime by other functions.
@@ -32,6 +37,9 @@ import sympy as sp  # SymPy: The Python computer algebra package upon which NRPy
 from nrpy import c_codegen, c_function, indexedexp
 from nrpy import params as par
 from nrpy import reference_metric
+from nrpy.infrastructures.BHaH.CurviBoundaryConditions.apply_bcs_outerradiation_and_inner import (
+    setup_Cfunction_r_and_partial_xi_partial_r_derivs,
+)
 
 
 # Set unit-vector dot products (=parity) for each of the 10 parity condition types
@@ -482,6 +490,7 @@ def register_CFunction_bcstruct_set_up(
         CoordSystem
     )
     prefunc += Cfunction__set_parity_for_inner_boundary_single_pt(CoordSystem)
+    prefunc += setup_Cfunction_r_and_partial_xi_partial_r_derivs(CoordSystem)
     parallelization = par.parval_from_str("parallelization")
     desc = r"""At each coordinate point (x0,x1,x2) situated at grid index (i0,i1,i2):
 Step 1: Set up inner boundary structs bcstruct->inner_bc_array[].
@@ -504,17 +513,14 @@ Step 1: Set up inner boundary structs bcstruct->inner_bc_array[].
     If (i0,i1,i2) *is* the same as (i0_inbounds,i1_inbounds,i2_inbounds),
         then we are at an outer boundary point. Take care of outer BCs in Step 2.
 Step 2: Set up outer boundary structs bcstruct->outer_bc_array[which_gz][face][idx2d]:
-  Recall that at each inner boundary point we must set outerpt_bc_struct:
-    typedef struct __outerpt_bc_struct__ {
-      short i0,i1,i2;  // the outer boundary point grid index (i0,i1,i2), on the 3D grid
-      int8_t FACEX0,FACEX1,FACEX2;  // 1-byte integers that store
-      //                               FACEX0,FACEX1,FACEX2 = +1, 0, 0 if on the i0=i0min face,
-      //                               FACEX0,FACEX1,FACEX2 = -1, 0, 0 if on the i0=i0max face,
-      //                               FACEX0,FACEX1,FACEX2 =  0,+1, 0 if on the i1=i2min face,
-      //                               FACEX0,FACEX1,FACEX2 =  0,-1, 0 if on the i1=i1max face,
-      //                               FACEX0,FACEX1,FACEX2 =  0, 0,+1 if on the i2=i2min face, or
-      //                               FACEX0,FACEX1,FACEX2 =  0, 0,-1 if on the i2=i2max face,
-    } outerpt_bc_struct;
+  Recall that at each outer boundary point, outerpt_bc_struct stores:
+    i0,i1,i2: the outer boundary point grid index on the 3D grid
+    FACEX0,FACEX1,FACEX2: face signs, e.g. +1,0,0 on the i0=i0min face and -1,0,0 on the i0=i0max face
+    r, partial_x{0,1,2}_partial_r: the radius and dx^i/dr at this point, precomputed here because they
+      are grid-static; the radiation BC would otherwise recompute them for every gridfunction on every
+      RK substep
+    r_int, partial_x{0,1,2}_partial_r_int: the same quantities at the nearest interior neighbour,
+      (i0,i1,i2)+(FACEX0,FACEX1,FACEX2)
   Outer boundary points are filled from the inside out, two faces at a time.
     E.g., consider a Cartesian coordinate grid that has 14 points in each direction,
     including the ghostzones, with NGHOSTS=2.
@@ -726,6 +732,19 @@ Step 2: Set up outer boundary structs bcstruct->outer_bc_array[which_gz][face][i
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on lower faces
@@ -752,6 +771,19 @@ Step 2: Set up outer boundary structs bcstruct->outer_bc_array[which_gz][face][i
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on upper faces

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__cuda__Cartesian.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__cuda__Cartesian.cu
@@ -137,29 +137,6 @@ __device__ static inline REAL FD1_arbitrary_upwind_x2_dirn(const size_t streamid
   return 0.0 / 0.0; // poison output if offset computed incorrectly
 } // END FUNCTION: FD1_arbitrary_upwind_x2_dirn
 /**
- * Compute r(xx0,xx1,xx2) and partial_r x^i.
- */
-__device__ static inline void r_and_partial_xi_partial_r_derivs(const size_t streamid, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
-                                                                REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
-  const REAL tmp0 = ((xx2) * (xx2));
-  const REAL tmp3 = ((xx0) * (xx0)) + ((xx1) * (xx1));
-  const REAL tmp4 = tmp0 + tmp3;
-  const REAL tmp5 = sqrt(tmp4);
-  const REAL tmp6 = 1 / (tmp3 * sqrt(-tmp0 / tmp4 + 1));
-  const REAL tmp8 = tmp0 / ((tmp4) * (tmp4));
-  const REAL tmp11 = pow(tmp4, -3.0 / 2.0);
-  const REAL tmp7 = tmp6 * ((xx0) * (xx0));
-  const REAL tmp9 = tmp6 * ((xx1) * (xx1));
-  const REAL tmp10 = (1.0 / (tmp5));
-  const REAL tmp12 = -tmp0 * tmp11 + tmp10;
-  const REAL tmp14 = (1.0 / (tmp10 * tmp12 * tmp7 + tmp10 * tmp12 * tmp9 + tmp7 * tmp8 + tmp8 * tmp9));
-  const REAL tmp15 = tmp12 * tmp14 * tmp6;
-  *r = tmp5;
-  *partial_x0_partial_r = tmp15 * xx0;
-  *partial_x1_partial_r = tmp15 * xx1;
-  *partial_x2_partial_r = tmp14 * (tmp11 * tmp7 * xx2 + tmp11 * tmp9 * xx2);
-} // END FUNCTION: r_and_partial_xi_partial_r_derivs
-/**
  * Compute \partial_r f
  */
 __device__ static inline REAL compute_partial_r_f(const size_t streamid, REAL *restrict xx[3], const REAL *restrict gfs, const int which_gf,
@@ -231,7 +208,10 @@ __device__ static inline REAL compute_partial_r_f(const size_t streamid, REAL *r
  */
 __device__ static inline REAL radiation_bcs(const size_t streamid, REAL *restrict xx[3], const REAL *restrict gfs, REAL *restrict gfs_rhss,
                                             const int which_gf, const REAL gf_wavespeed, const REAL gf_f_infinity, const int dest_i0,
-                                            const int dest_i1, const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2) {
+                                            const int dest_i1, const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2,
+                                            const REAL r, const REAL partial_x0_partial_r, const REAL partial_x1_partial_r,
+                                            const REAL partial_x2_partial_r, const REAL r_int, const REAL partial_x0_partial_r_int,
+                                            const REAL partial_x1_partial_r_int, const REAL partial_x2_partial_r_int) {
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = d_params[streamid].Nxx_plus_2NGHOSTS0;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = d_params[streamid].Nxx_plus_2NGHOSTS1;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = d_params[streamid].Nxx_plus_2NGHOSTS2;
@@ -250,12 +230,6 @@ __device__ static inline REAL radiation_bcs(const size_t streamid, REAL *restric
 
   // Nearest "interior" neighbor of this gridpoint, based on current face
   const int dest_i0_int = dest_i0 + 1 * FACEi0, dest_i1_int = dest_i1 + 1 * FACEi1, dest_i2_int = dest_i2 + 1 * FACEi2;
-  REAL r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r;
-  REAL r_int, partial_x0_partial_r_int, partial_x1_partial_r_int, partial_x2_partial_r_int;
-  r_and_partial_xi_partial_r_derivs(streamid, xx[0][dest_i0], xx[1][dest_i1], xx[2][dest_i2], &r, &partial_x0_partial_r, &partial_x1_partial_r,
-                                    &partial_x2_partial_r);
-  r_and_partial_xi_partial_r_derivs(streamid, xx[0][dest_i0_int], xx[1][dest_i1_int], xx[2][dest_i2_int], &r_int, &partial_x0_partial_r_int,
-                                    &partial_x1_partial_r_int, &partial_x2_partial_r_int);
   const REAL partial_r_f = compute_partial_r_f(streamid, xx, gfs, which_gf, dest_i0, dest_i1, dest_i2, FACEi0, FACEi1, FACEi2, partial_x0_partial_r,
                                                partial_x1_partial_r, partial_x2_partial_r);
   const REAL partial_r_f_int = compute_partial_r_f(streamid, xx, gfs, which_gf, dest_i0_int, dest_i1_int, dest_i2_int, FACEi0, FACEi1, FACEi2,
@@ -311,10 +285,20 @@ __global__ static void apply_bcs_pure_only_gpu(const size_t streamid, const int 
     const short FACEX2 = pure_outer_bc_array[idx2d].FACEX2;
     const int idx3 = IDX3(i0, i1, i2);
     REAL *xx[3] = {x0, x1, x2};
+    const REAL r = pure_outer_bc_array[idx2d].r;
+    const REAL partial_x0_partial_r = pure_outer_bc_array[idx2d].partial_x0_partial_r;
+    const REAL partial_x1_partial_r = pure_outer_bc_array[idx2d].partial_x1_partial_r;
+    const REAL partial_x2_partial_r = pure_outer_bc_array[idx2d].partial_x2_partial_r;
+    const REAL r_int = pure_outer_bc_array[idx2d].r_int;
+    const REAL partial_x0_partial_r_int = pure_outer_bc_array[idx2d].partial_x0_partial_r_int;
+    const REAL partial_x1_partial_r_int = pure_outer_bc_array[idx2d].partial_x1_partial_r_int;
+    const REAL partial_x2_partial_r_int = pure_outer_bc_array[idx2d].partial_x2_partial_r_int;
     for (int which_gf = 0; which_gf < NUM_EVOL_GFS; which_gf++) {
       // *** Apply radiation BCs to all outer boundary points. ***
-      rhs_gfs[IDX4pt(which_gf, idx3)] = radiation_bcs(streamid, xx, gfs, rhs_gfs, which_gf, d_gridfunctions_wavespeed[which_gf],
-                                                      d_gridfunctions_f_infinity[which_gf], i0, i1, i2, FACEX0, FACEX1, FACEX2);
+      rhs_gfs[IDX4pt(which_gf, idx3)] =
+          radiation_bcs(streamid, xx, gfs, rhs_gfs, which_gf, d_gridfunctions_wavespeed[which_gf], d_gridfunctions_f_infinity[which_gf], i0, i1, i2,
+                        FACEX0, FACEX1, FACEX2, r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r, r_int, partial_x0_partial_r_int,
+                        partial_x1_partial_r_int, partial_x2_partial_r_int);
     }
   }
 } // END FUNCTION: apply_bcs_pure_only_gpu

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__cuda__HoleySinhSpherical.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__cuda__HoleySinhSpherical.cu
@@ -47,23 +47,6 @@ __device__ static inline REAL FD1_arbitrary_upwind_x0_dirn(const size_t streamid
   return 0.0 / 0.0; // poison output if offset computed incorrectly
 } // END FUNCTION: FD1_arbitrary_upwind_x0_dirn
 /**
- * Compute r(xx0,xx1,xx2) and partial_r x^i.
- */
-__device__ static inline void r_and_partial_xi_partial_r_derivs(const size_t streamid, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
-                                                                REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
-  const REAL AMPL = d_params[streamid].AMPL;
-  const REAL SINHW = d_params[streamid].SINHW;
-
-  const REAL tmp0 = (1.0 / (SINHW));
-  const REAL tmp1 = exp(tmp0) - exp(-tmp0);
-  const REAL tmp3 = exp(tmp0 * xx0);
-  const REAL tmp4 = exp(-tmp0 * xx0);
-  *r = AMPL * (tmp3 - tmp4) / tmp1;
-  *partial_x0_partial_r = tmp1 / (AMPL * (tmp0 * tmp3 + tmp0 * tmp4));
-  *partial_x1_partial_r = 0;
-  *partial_x2_partial_r = 0;
-} // END FUNCTION: r_and_partial_xi_partial_r_derivs
-/**
  * Compute \partial_r f
  */
 __device__ static inline REAL compute_partial_r_f(const size_t streamid, REAL *restrict xx[3], const REAL *restrict gfs, const int which_gf,
@@ -123,7 +106,10 @@ __device__ static inline REAL compute_partial_r_f(const size_t streamid, REAL *r
  */
 __device__ static inline REAL radiation_bcs(const size_t streamid, REAL *restrict xx[3], const REAL *restrict gfs, REAL *restrict gfs_rhss,
                                             const int which_gf, const REAL gf_wavespeed, const REAL gf_f_infinity, const int dest_i0,
-                                            const int dest_i1, const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2) {
+                                            const int dest_i1, const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2,
+                                            const REAL r, const REAL partial_x0_partial_r, const REAL partial_x1_partial_r,
+                                            const REAL partial_x2_partial_r, const REAL r_int, const REAL partial_x0_partial_r_int,
+                                            const REAL partial_x1_partial_r_int, const REAL partial_x2_partial_r_int) {
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = d_params[streamid].Nxx_plus_2NGHOSTS0;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = d_params[streamid].Nxx_plus_2NGHOSTS1;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = d_params[streamid].Nxx_plus_2NGHOSTS2;
@@ -142,12 +128,6 @@ __device__ static inline REAL radiation_bcs(const size_t streamid, REAL *restric
 
   // Nearest "interior" neighbor of this gridpoint, based on current face
   const int dest_i0_int = dest_i0 + 1 * FACEi0, dest_i1_int = dest_i1 + 1 * FACEi1, dest_i2_int = dest_i2 + 1 * FACEi2;
-  REAL r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r;
-  REAL r_int, partial_x0_partial_r_int, partial_x1_partial_r_int, partial_x2_partial_r_int;
-  r_and_partial_xi_partial_r_derivs(streamid, xx[0][dest_i0], xx[1][dest_i1], xx[2][dest_i2], &r, &partial_x0_partial_r, &partial_x1_partial_r,
-                                    &partial_x2_partial_r);
-  r_and_partial_xi_partial_r_derivs(streamid, xx[0][dest_i0_int], xx[1][dest_i1_int], xx[2][dest_i2_int], &r_int, &partial_x0_partial_r_int,
-                                    &partial_x1_partial_r_int, &partial_x2_partial_r_int);
   const REAL partial_r_f = compute_partial_r_f(streamid, xx, gfs, which_gf, dest_i0, dest_i1, dest_i2, FACEi0, FACEi1, FACEi2, partial_x0_partial_r,
                                                partial_x1_partial_r, partial_x2_partial_r);
   const REAL partial_r_f_int = compute_partial_r_f(streamid, xx, gfs, which_gf, dest_i0_int, dest_i1_int, dest_i2_int, FACEi0, FACEi1, FACEi2,
@@ -203,10 +183,20 @@ __global__ static void apply_bcs_pure_only_gpu(const size_t streamid, const int 
     const short FACEX2 = pure_outer_bc_array[idx2d].FACEX2;
     const int idx3 = IDX3(i0, i1, i2);
     REAL *xx[3] = {x0, x1, x2};
+    const REAL r = pure_outer_bc_array[idx2d].r;
+    const REAL partial_x0_partial_r = pure_outer_bc_array[idx2d].partial_x0_partial_r;
+    const REAL partial_x1_partial_r = pure_outer_bc_array[idx2d].partial_x1_partial_r;
+    const REAL partial_x2_partial_r = pure_outer_bc_array[idx2d].partial_x2_partial_r;
+    const REAL r_int = pure_outer_bc_array[idx2d].r_int;
+    const REAL partial_x0_partial_r_int = pure_outer_bc_array[idx2d].partial_x0_partial_r_int;
+    const REAL partial_x1_partial_r_int = pure_outer_bc_array[idx2d].partial_x1_partial_r_int;
+    const REAL partial_x2_partial_r_int = pure_outer_bc_array[idx2d].partial_x2_partial_r_int;
     for (int which_gf = 0; which_gf < NUM_EVOL_GFS; which_gf++) {
       // *** Apply radiation BCs to all outer boundary points. ***
-      rhs_gfs[IDX4pt(which_gf, idx3)] = radiation_bcs(streamid, xx, gfs, rhs_gfs, which_gf, d_gridfunctions_wavespeed[which_gf],
-                                                      d_gridfunctions_f_infinity[which_gf], i0, i1, i2, FACEX0, FACEX1, FACEX2);
+      rhs_gfs[IDX4pt(which_gf, idx3)] =
+          radiation_bcs(streamid, xx, gfs, rhs_gfs, which_gf, d_gridfunctions_wavespeed[which_gf], d_gridfunctions_f_infinity[which_gf], i0, i1, i2,
+                        FACEX0, FACEX1, FACEX2, r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r, r_int, partial_x0_partial_r_int,
+                        partial_x1_partial_r_int, partial_x2_partial_r_int);
     }
   }
 } // END FUNCTION: apply_bcs_pure_only_gpu

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__cuda__SinhCylindricalv2n2.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__cuda__SinhCylindricalv2n2.cu
@@ -92,51 +92,6 @@ __device__ static inline REAL FD1_arbitrary_upwind_x2_dirn(const size_t streamid
   return 0.0 / 0.0; // poison output if offset computed incorrectly
 } // END FUNCTION: FD1_arbitrary_upwind_x2_dirn
 /**
- * Compute r(xx0,xx1,xx2) and partial_r x^i.
- */
-__device__ static inline void r_and_partial_xi_partial_r_derivs(const size_t streamid, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
-                                                                REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
-  const REAL AMPLRHO = d_params[streamid].AMPLRHO;
-  const REAL AMPLZ = d_params[streamid].AMPLZ;
-  const REAL SINHWRHO = d_params[streamid].SINHWRHO;
-  const REAL SINHWZ = d_params[streamid].SINHWZ;
-  const REAL rho_slope = d_params[streamid].rho_slope;
-  const REAL z_slope = d_params[streamid].z_slope;
-
-  const REAL tmp0 = (1.0 / (SINHWRHO));
-  const REAL tmp6 = AMPLRHO - rho_slope;
-  const REAL tmp9 = (1.0 / (SINHWZ));
-  const REAL tmp15 = AMPLZ - z_slope;
-  const REAL tmp5 = (1.0 / (exp(tmp0) - exp(-tmp0)));
-  const REAL tmp14 = (1.0 / (exp(tmp9) - exp(-tmp9)));
-  const REAL tmp2 = exp(tmp0 * xx0);
-  const REAL tmp3 = exp(-tmp0 * xx0);
-  const REAL tmp7 = tmp5 * tmp6 * ((xx0) * (xx0));
-  const REAL tmp11 = exp(tmp9 * xx2);
-  const REAL tmp12 = exp(-tmp9 * xx2);
-  const REAL tmp16 = tmp14 * tmp15 * ((xx2) * (xx2));
-  const REAL tmp4 = tmp2 - tmp3;
-  const REAL tmp13 = tmp11 - tmp12;
-  const REAL tmp22 = tmp16 * (tmp11 * tmp9 + tmp12 * tmp9);
-  const REAL tmp8 = rho_slope * xx0 + tmp4 * tmp7;
-  const REAL tmp17 = tmp13 * tmp16 + xx2 * z_slope;
-  const REAL tmp21 = tmp13 * tmp14 * tmp15 * xx2;
-  const REAL tmp18 = ((tmp17) * (tmp17));
-  const REAL tmp25 = tmp8 * (2 * rho_slope + 4 * tmp4 * tmp5 * tmp6 * xx0 + 2 * tmp7 * (tmp0 * tmp2 + tmp0 * tmp3));
-  const REAL tmp19 = tmp18 + ((tmp8) * (tmp8));
-  const REAL tmp23 = tmp18 * (4 * tmp21 + 2 * tmp22 + 2 * z_slope);
-  const REAL tmp20 = sqrt(tmp19);
-  const REAL tmp24 = (1.0 / sqrt(-tmp18 / tmp19 + 1));
-  const REAL tmp28 = (1.0 / 2.0) / pow(tmp19, 3.0 / 2.0);
-  const REAL tmp27 = (1.0 / (tmp20));
-  const REAL tmp29 = tmp24 * (-tmp23 * tmp28 + tmp27 * (2 * tmp21 + tmp22 + z_slope));
-  const REAL tmp30 = (1.0 / ((1.0 / 2.0) * tmp25 * tmp27 * tmp29 + (1.0 / 4.0) * tmp23 * tmp24 * tmp25 / ((tmp19) * (tmp19))));
-  *r = tmp20;
-  *partial_x0_partial_r = tmp29 * tmp30;
-  *partial_x1_partial_r = 0;
-  *partial_x2_partial_r = tmp17 * tmp24 * tmp25 * tmp28 * tmp30;
-} // END FUNCTION: r_and_partial_xi_partial_r_derivs
-/**
  * Compute \partial_r f
  */
 __device__ static inline REAL compute_partial_r_f(const size_t streamid, REAL *restrict xx[3], const REAL *restrict gfs, const int which_gf,
@@ -202,7 +157,10 @@ __device__ static inline REAL compute_partial_r_f(const size_t streamid, REAL *r
  */
 __device__ static inline REAL radiation_bcs(const size_t streamid, REAL *restrict xx[3], const REAL *restrict gfs, REAL *restrict gfs_rhss,
                                             const int which_gf, const REAL gf_wavespeed, const REAL gf_f_infinity, const int dest_i0,
-                                            const int dest_i1, const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2) {
+                                            const int dest_i1, const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2,
+                                            const REAL r, const REAL partial_x0_partial_r, const REAL partial_x1_partial_r,
+                                            const REAL partial_x2_partial_r, const REAL r_int, const REAL partial_x0_partial_r_int,
+                                            const REAL partial_x1_partial_r_int, const REAL partial_x2_partial_r_int) {
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = d_params[streamid].Nxx_plus_2NGHOSTS0;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = d_params[streamid].Nxx_plus_2NGHOSTS1;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = d_params[streamid].Nxx_plus_2NGHOSTS2;
@@ -221,12 +179,6 @@ __device__ static inline REAL radiation_bcs(const size_t streamid, REAL *restric
 
   // Nearest "interior" neighbor of this gridpoint, based on current face
   const int dest_i0_int = dest_i0 + 1 * FACEi0, dest_i1_int = dest_i1 + 1 * FACEi1, dest_i2_int = dest_i2 + 1 * FACEi2;
-  REAL r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r;
-  REAL r_int, partial_x0_partial_r_int, partial_x1_partial_r_int, partial_x2_partial_r_int;
-  r_and_partial_xi_partial_r_derivs(streamid, xx[0][dest_i0], xx[1][dest_i1], xx[2][dest_i2], &r, &partial_x0_partial_r, &partial_x1_partial_r,
-                                    &partial_x2_partial_r);
-  r_and_partial_xi_partial_r_derivs(streamid, xx[0][dest_i0_int], xx[1][dest_i1_int], xx[2][dest_i2_int], &r_int, &partial_x0_partial_r_int,
-                                    &partial_x1_partial_r_int, &partial_x2_partial_r_int);
   const REAL partial_r_f = compute_partial_r_f(streamid, xx, gfs, which_gf, dest_i0, dest_i1, dest_i2, FACEi0, FACEi1, FACEi2, partial_x0_partial_r,
                                                partial_x1_partial_r, partial_x2_partial_r);
   const REAL partial_r_f_int = compute_partial_r_f(streamid, xx, gfs, which_gf, dest_i0_int, dest_i1_int, dest_i2_int, FACEi0, FACEi1, FACEi2,
@@ -282,10 +234,20 @@ __global__ static void apply_bcs_pure_only_gpu(const size_t streamid, const int 
     const short FACEX2 = pure_outer_bc_array[idx2d].FACEX2;
     const int idx3 = IDX3(i0, i1, i2);
     REAL *xx[3] = {x0, x1, x2};
+    const REAL r = pure_outer_bc_array[idx2d].r;
+    const REAL partial_x0_partial_r = pure_outer_bc_array[idx2d].partial_x0_partial_r;
+    const REAL partial_x1_partial_r = pure_outer_bc_array[idx2d].partial_x1_partial_r;
+    const REAL partial_x2_partial_r = pure_outer_bc_array[idx2d].partial_x2_partial_r;
+    const REAL r_int = pure_outer_bc_array[idx2d].r_int;
+    const REAL partial_x0_partial_r_int = pure_outer_bc_array[idx2d].partial_x0_partial_r_int;
+    const REAL partial_x1_partial_r_int = pure_outer_bc_array[idx2d].partial_x1_partial_r_int;
+    const REAL partial_x2_partial_r_int = pure_outer_bc_array[idx2d].partial_x2_partial_r_int;
     for (int which_gf = 0; which_gf < NUM_EVOL_GFS; which_gf++) {
       // *** Apply radiation BCs to all outer boundary points. ***
-      rhs_gfs[IDX4pt(which_gf, idx3)] = radiation_bcs(streamid, xx, gfs, rhs_gfs, which_gf, d_gridfunctions_wavespeed[which_gf],
-                                                      d_gridfunctions_f_infinity[which_gf], i0, i1, i2, FACEX0, FACEX1, FACEX2);
+      rhs_gfs[IDX4pt(which_gf, idx3)] =
+          radiation_bcs(streamid, xx, gfs, rhs_gfs, which_gf, d_gridfunctions_wavespeed[which_gf], d_gridfunctions_f_infinity[which_gf], i0, i1, i2,
+                        FACEX0, FACEX1, FACEX2, r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r, r_int, partial_x0_partial_r_int,
+                        partial_x1_partial_r_int, partial_x2_partial_r_int);
     }
   }
 } // END FUNCTION: apply_bcs_pure_only_gpu

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__cuda__SinhSymTP.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__cuda__SinhSymTP.cu
@@ -92,42 +92,6 @@ __device__ static inline REAL FD1_arbitrary_upwind_x1_dirn(const size_t streamid
   return 0.0 / 0.0; // poison output if offset computed incorrectly
 } // END FUNCTION: FD1_arbitrary_upwind_x1_dirn
 /**
- * Compute r(xx0,xx1,xx2) and partial_r x^i.
- */
-__device__ static inline void r_and_partial_xi_partial_r_derivs(const size_t streamid, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
-                                                                REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
-  const REAL AMAX = d_params[streamid].AMAX;
-  const REAL SINHWAA = d_params[streamid].SINHWAA;
-  const REAL bScale = d_params[streamid].bScale;
-
-  const REAL tmp0 = sin(xx1);
-  const REAL tmp2 = (1.0 / (SINHWAA));
-  const REAL tmp9 = cos(xx1);
-  const REAL tmp7 = ((AMAX) * (AMAX)) / ((exp(tmp2) - exp(-tmp2)) * (exp(tmp2) - exp(-tmp2)));
-  const REAL tmp4 = exp(tmp2 * xx0);
-  const REAL tmp5 = exp(-tmp2 * xx0);
-  const REAL tmp6 = tmp4 - tmp5;
-  const REAL tmp8 = ((tmp6) * (tmp6)) * tmp7;
-  const REAL tmp23 = (1.0 / 2.0) * tmp6 * tmp7 * (2 * tmp2 * tmp4 + 2 * tmp2 * tmp5);
-  const REAL tmp11 = ((bScale) * (bScale)) + tmp8;
-  const REAL tmp24 = ((tmp0) * (tmp0)) * tmp23 + tmp23 * ((tmp9) * (tmp9));
-  const REAL tmp12 = tmp11 * ((tmp9) * (tmp9));
-  const REAL tmp15 = sqrt(tmp11);
-  const REAL tmp18 = -tmp0 * tmp11 * tmp9 + tmp0 * tmp8 * tmp9;
-  const REAL tmp13 = ((tmp0) * (tmp0)) * tmp8 + tmp12;
-  const REAL tmp14 = sqrt(tmp13);
-  const REAL tmp19 = pow(tmp13, -3.0 / 2.0);
-  const REAL tmp21 = (1.0 / sqrt(-tmp12 / tmp13 + 1));
-  const REAL tmp16 = (1.0 / (tmp14));
-  const REAL tmp20 = -tmp0 * tmp15 * tmp16 - tmp15 * tmp18 * tmp19 * tmp9;
-  const REAL tmp25 = -tmp15 * tmp19 * tmp24 * tmp9 + tmp16 * tmp23 * tmp9 / tmp15;
-  const REAL tmp26 = tmp21 / (tmp16 * tmp18 * tmp21 * tmp25 - tmp16 * tmp20 * tmp21 * tmp24);
-  *r = tmp14;
-  *partial_x0_partial_r = -tmp20 * tmp26;
-  *partial_x1_partial_r = tmp25 * tmp26;
-  *partial_x2_partial_r = 0;
-} // END FUNCTION: r_and_partial_xi_partial_r_derivs
-/**
  * Compute \partial_r f
  */
 __device__ static inline REAL compute_partial_r_f(const size_t streamid, REAL *restrict xx[3], const REAL *restrict gfs, const int which_gf,
@@ -193,7 +157,10 @@ __device__ static inline REAL compute_partial_r_f(const size_t streamid, REAL *r
  */
 __device__ static inline REAL radiation_bcs(const size_t streamid, REAL *restrict xx[3], const REAL *restrict gfs, REAL *restrict gfs_rhss,
                                             const int which_gf, const REAL gf_wavespeed, const REAL gf_f_infinity, const int dest_i0,
-                                            const int dest_i1, const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2) {
+                                            const int dest_i1, const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2,
+                                            const REAL r, const REAL partial_x0_partial_r, const REAL partial_x1_partial_r,
+                                            const REAL partial_x2_partial_r, const REAL r_int, const REAL partial_x0_partial_r_int,
+                                            const REAL partial_x1_partial_r_int, const REAL partial_x2_partial_r_int) {
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = d_params[streamid].Nxx_plus_2NGHOSTS0;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = d_params[streamid].Nxx_plus_2NGHOSTS1;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = d_params[streamid].Nxx_plus_2NGHOSTS2;
@@ -212,12 +179,6 @@ __device__ static inline REAL radiation_bcs(const size_t streamid, REAL *restric
 
   // Nearest "interior" neighbor of this gridpoint, based on current face
   const int dest_i0_int = dest_i0 + 1 * FACEi0, dest_i1_int = dest_i1 + 1 * FACEi1, dest_i2_int = dest_i2 + 1 * FACEi2;
-  REAL r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r;
-  REAL r_int, partial_x0_partial_r_int, partial_x1_partial_r_int, partial_x2_partial_r_int;
-  r_and_partial_xi_partial_r_derivs(streamid, xx[0][dest_i0], xx[1][dest_i1], xx[2][dest_i2], &r, &partial_x0_partial_r, &partial_x1_partial_r,
-                                    &partial_x2_partial_r);
-  r_and_partial_xi_partial_r_derivs(streamid, xx[0][dest_i0_int], xx[1][dest_i1_int], xx[2][dest_i2_int], &r_int, &partial_x0_partial_r_int,
-                                    &partial_x1_partial_r_int, &partial_x2_partial_r_int);
   const REAL partial_r_f = compute_partial_r_f(streamid, xx, gfs, which_gf, dest_i0, dest_i1, dest_i2, FACEi0, FACEi1, FACEi2, partial_x0_partial_r,
                                                partial_x1_partial_r, partial_x2_partial_r);
   const REAL partial_r_f_int = compute_partial_r_f(streamid, xx, gfs, which_gf, dest_i0_int, dest_i1_int, dest_i2_int, FACEi0, FACEi1, FACEi2,
@@ -273,10 +234,20 @@ __global__ static void apply_bcs_pure_only_gpu(const size_t streamid, const int 
     const short FACEX2 = pure_outer_bc_array[idx2d].FACEX2;
     const int idx3 = IDX3(i0, i1, i2);
     REAL *xx[3] = {x0, x1, x2};
+    const REAL r = pure_outer_bc_array[idx2d].r;
+    const REAL partial_x0_partial_r = pure_outer_bc_array[idx2d].partial_x0_partial_r;
+    const REAL partial_x1_partial_r = pure_outer_bc_array[idx2d].partial_x1_partial_r;
+    const REAL partial_x2_partial_r = pure_outer_bc_array[idx2d].partial_x2_partial_r;
+    const REAL r_int = pure_outer_bc_array[idx2d].r_int;
+    const REAL partial_x0_partial_r_int = pure_outer_bc_array[idx2d].partial_x0_partial_r_int;
+    const REAL partial_x1_partial_r_int = pure_outer_bc_array[idx2d].partial_x1_partial_r_int;
+    const REAL partial_x2_partial_r_int = pure_outer_bc_array[idx2d].partial_x2_partial_r_int;
     for (int which_gf = 0; which_gf < NUM_EVOL_GFS; which_gf++) {
       // *** Apply radiation BCs to all outer boundary points. ***
-      rhs_gfs[IDX4pt(which_gf, idx3)] = radiation_bcs(streamid, xx, gfs, rhs_gfs, which_gf, d_gridfunctions_wavespeed[which_gf],
-                                                      d_gridfunctions_f_infinity[which_gf], i0, i1, i2, FACEX0, FACEX1, FACEX2);
+      rhs_gfs[IDX4pt(which_gf, idx3)] =
+          radiation_bcs(streamid, xx, gfs, rhs_gfs, which_gf, d_gridfunctions_wavespeed[which_gf], d_gridfunctions_f_infinity[which_gf], i0, i1, i2,
+                        FACEX0, FACEX1, FACEX2, r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r, r_int, partial_x0_partial_r_int,
+                        partial_x1_partial_r_int, partial_x2_partial_r_int);
     }
   }
 } // END FUNCTION: apply_bcs_pure_only_gpu

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__openmp__Cartesian.c
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__openmp__Cartesian.c
@@ -113,29 +113,6 @@ static inline REAL FD1_arbitrary_upwind_x2_dirn(const params_struct *restrict pa
   return 0.0 / 0.0; // poison output if offset computed incorrectly
 } // END FUNCTION: FD1_arbitrary_upwind_x2_dirn
 /**
- * Compute r(xx0,xx1,xx2) and partial_r x^i.
- */
-static inline void r_and_partial_xi_partial_r_derivs(const params_struct *restrict params, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
-                                                     REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
-  const REAL tmp0 = ((xx2) * (xx2));
-  const REAL tmp3 = ((xx0) * (xx0)) + ((xx1) * (xx1));
-  const REAL tmp4 = tmp0 + tmp3;
-  const REAL tmp5 = sqrt(tmp4);
-  const REAL tmp6 = 1 / (tmp3 * sqrt(-tmp0 / tmp4 + 1));
-  const REAL tmp8 = tmp0 / ((tmp4) * (tmp4));
-  const REAL tmp11 = pow(tmp4, -3.0 / 2.0);
-  const REAL tmp7 = tmp6 * ((xx0) * (xx0));
-  const REAL tmp9 = tmp6 * ((xx1) * (xx1));
-  const REAL tmp10 = (1.0 / (tmp5));
-  const REAL tmp12 = -tmp0 * tmp11 + tmp10;
-  const REAL tmp14 = (1.0 / (tmp10 * tmp12 * tmp7 + tmp10 * tmp12 * tmp9 + tmp7 * tmp8 + tmp8 * tmp9));
-  const REAL tmp15 = tmp12 * tmp14 * tmp6;
-  *r = tmp5;
-  *partial_x0_partial_r = tmp15 * xx0;
-  *partial_x1_partial_r = tmp15 * xx1;
-  *partial_x2_partial_r = tmp14 * (tmp11 * tmp7 * xx2 + tmp11 * tmp9 * xx2);
-} // END FUNCTION: r_and_partial_xi_partial_r_derivs
-/**
  * Compute \partial_r f
  */
 static inline REAL compute_partial_r_f(const params_struct *restrict params, REAL *restrict xx[3], const REAL *restrict gfs, const int which_gf,
@@ -198,7 +175,9 @@ static inline REAL compute_partial_r_f(const params_struct *restrict params, REA
  */
 static inline REAL radiation_bcs(const params_struct *restrict params, REAL *restrict xx[3], const REAL *restrict gfs, REAL *restrict gfs_rhss,
                                  const int which_gf, const REAL gf_wavespeed, const REAL gf_f_infinity, const int dest_i0, const int dest_i1,
-                                 const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2) {
+                                 const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2, const REAL r,
+                                 const REAL partial_x0_partial_r, const REAL partial_x1_partial_r, const REAL partial_x2_partial_r, const REAL r_int,
+                                 const REAL partial_x0_partial_r_int, const REAL partial_x1_partial_r_int, const REAL partial_x2_partial_r_int) {
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
@@ -209,12 +188,6 @@ static inline REAL radiation_bcs(const params_struct *restrict params, REAL *res
 
   // Nearest "interior" neighbor of this gridpoint, based on current face
   const int dest_i0_int = dest_i0 + 1 * FACEi0, dest_i1_int = dest_i1 + 1 * FACEi1, dest_i2_int = dest_i2 + 1 * FACEi2;
-  REAL r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r;
-  REAL r_int, partial_x0_partial_r_int, partial_x1_partial_r_int, partial_x2_partial_r_int;
-  r_and_partial_xi_partial_r_derivs(params, xx[0][dest_i0], xx[1][dest_i1], xx[2][dest_i2], &r, &partial_x0_partial_r, &partial_x1_partial_r,
-                                    &partial_x2_partial_r);
-  r_and_partial_xi_partial_r_derivs(params, xx[0][dest_i0_int], xx[1][dest_i1_int], xx[2][dest_i2_int], &r_int, &partial_x0_partial_r_int,
-                                    &partial_x1_partial_r_int, &partial_x2_partial_r_int);
   const REAL partial_r_f = compute_partial_r_f(params, xx, gfs, which_gf, dest_i0, dest_i1, dest_i2, FACEi0, FACEi1, FACEi2, partial_x0_partial_r,
                                                partial_x1_partial_r, partial_x2_partial_r);
   const REAL partial_r_f_int = compute_partial_r_f(params, xx, gfs, which_gf, dest_i0_int, dest_i1_int, dest_i2_int, FACEi0, FACEi1, FACEi2,
@@ -264,10 +237,20 @@ static void apply_bcs_pure_only_host(const params_struct *restrict params, const
     const short FACEX2 = pure_outer_bc_array[idx2d].FACEX2;
     const int idx3 = IDX3(i0, i1, i2);
     REAL *xx[3] = {x0, x1, x2};
+    const REAL r = pure_outer_bc_array[idx2d].r;
+    const REAL partial_x0_partial_r = pure_outer_bc_array[idx2d].partial_x0_partial_r;
+    const REAL partial_x1_partial_r = pure_outer_bc_array[idx2d].partial_x1_partial_r;
+    const REAL partial_x2_partial_r = pure_outer_bc_array[idx2d].partial_x2_partial_r;
+    const REAL r_int = pure_outer_bc_array[idx2d].r_int;
+    const REAL partial_x0_partial_r_int = pure_outer_bc_array[idx2d].partial_x0_partial_r_int;
+    const REAL partial_x1_partial_r_int = pure_outer_bc_array[idx2d].partial_x1_partial_r_int;
+    const REAL partial_x2_partial_r_int = pure_outer_bc_array[idx2d].partial_x2_partial_r_int;
     for (int which_gf = 0; which_gf < NUM_EVOL_GFS; which_gf++) {
       // *** Apply radiation BCs to all outer boundary points. ***
-      rhs_gfs[IDX4pt(which_gf, idx3)] = radiation_bcs(params, xx, gfs, rhs_gfs, which_gf, custom_wavespeed[which_gf], custom_f_infinity[which_gf], i0,
-                                                      i1, i2, FACEX0, FACEX1, FACEX2);
+      rhs_gfs[IDX4pt(which_gf, idx3)] =
+          radiation_bcs(params, xx, gfs, rhs_gfs, which_gf, custom_wavespeed[which_gf], custom_f_infinity[which_gf], i0, i1, i2, FACEX0, FACEX1,
+                        FACEX2, r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r, r_int, partial_x0_partial_r_int,
+                        partial_x1_partial_r_int, partial_x2_partial_r_int);
     }
   }
 } // END FUNCTION: apply_bcs_pure_only_host

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__openmp__HoleySinhSpherical.c
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__openmp__HoleySinhSpherical.c
@@ -39,23 +39,6 @@ static inline REAL FD1_arbitrary_upwind_x0_dirn(const params_struct *restrict pa
   return 0.0 / 0.0; // poison output if offset computed incorrectly
 } // END FUNCTION: FD1_arbitrary_upwind_x0_dirn
 /**
- * Compute r(xx0,xx1,xx2) and partial_r x^i.
- */
-static inline void r_and_partial_xi_partial_r_derivs(const params_struct *restrict params, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
-                                                     REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
-  const REAL AMPL = params->AMPL;
-  const REAL SINHW = params->SINHW;
-
-  const REAL tmp0 = (1.0 / (SINHW));
-  const REAL tmp1 = exp(tmp0) - exp(-tmp0);
-  const REAL tmp3 = exp(tmp0 * xx0);
-  const REAL tmp4 = exp(-tmp0 * xx0);
-  *r = AMPL * (tmp3 - tmp4) / tmp1;
-  *partial_x0_partial_r = tmp1 / (AMPL * (tmp0 * tmp3 + tmp0 * tmp4));
-  *partial_x1_partial_r = 0;
-  *partial_x2_partial_r = 0;
-} // END FUNCTION: r_and_partial_xi_partial_r_derivs
-/**
  * Compute \partial_r f
  */
 static inline REAL compute_partial_r_f(const params_struct *restrict params, REAL *restrict xx[3], const REAL *restrict gfs, const int which_gf,
@@ -106,7 +89,9 @@ static inline REAL compute_partial_r_f(const params_struct *restrict params, REA
  */
 static inline REAL radiation_bcs(const params_struct *restrict params, REAL *restrict xx[3], const REAL *restrict gfs, REAL *restrict gfs_rhss,
                                  const int which_gf, const REAL gf_wavespeed, const REAL gf_f_infinity, const int dest_i0, const int dest_i1,
-                                 const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2) {
+                                 const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2, const REAL r,
+                                 const REAL partial_x0_partial_r, const REAL partial_x1_partial_r, const REAL partial_x2_partial_r, const REAL r_int,
+                                 const REAL partial_x0_partial_r_int, const REAL partial_x1_partial_r_int, const REAL partial_x2_partial_r_int) {
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
@@ -117,12 +102,6 @@ static inline REAL radiation_bcs(const params_struct *restrict params, REAL *res
 
   // Nearest "interior" neighbor of this gridpoint, based on current face
   const int dest_i0_int = dest_i0 + 1 * FACEi0, dest_i1_int = dest_i1 + 1 * FACEi1, dest_i2_int = dest_i2 + 1 * FACEi2;
-  REAL r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r;
-  REAL r_int, partial_x0_partial_r_int, partial_x1_partial_r_int, partial_x2_partial_r_int;
-  r_and_partial_xi_partial_r_derivs(params, xx[0][dest_i0], xx[1][dest_i1], xx[2][dest_i2], &r, &partial_x0_partial_r, &partial_x1_partial_r,
-                                    &partial_x2_partial_r);
-  r_and_partial_xi_partial_r_derivs(params, xx[0][dest_i0_int], xx[1][dest_i1_int], xx[2][dest_i2_int], &r_int, &partial_x0_partial_r_int,
-                                    &partial_x1_partial_r_int, &partial_x2_partial_r_int);
   const REAL partial_r_f = compute_partial_r_f(params, xx, gfs, which_gf, dest_i0, dest_i1, dest_i2, FACEi0, FACEi1, FACEi2, partial_x0_partial_r,
                                                partial_x1_partial_r, partial_x2_partial_r);
   const REAL partial_r_f_int = compute_partial_r_f(params, xx, gfs, which_gf, dest_i0_int, dest_i1_int, dest_i2_int, FACEi0, FACEi1, FACEi2,
@@ -172,10 +151,20 @@ static void apply_bcs_pure_only_host(const params_struct *restrict params, const
     const short FACEX2 = pure_outer_bc_array[idx2d].FACEX2;
     const int idx3 = IDX3(i0, i1, i2);
     REAL *xx[3] = {x0, x1, x2};
+    const REAL r = pure_outer_bc_array[idx2d].r;
+    const REAL partial_x0_partial_r = pure_outer_bc_array[idx2d].partial_x0_partial_r;
+    const REAL partial_x1_partial_r = pure_outer_bc_array[idx2d].partial_x1_partial_r;
+    const REAL partial_x2_partial_r = pure_outer_bc_array[idx2d].partial_x2_partial_r;
+    const REAL r_int = pure_outer_bc_array[idx2d].r_int;
+    const REAL partial_x0_partial_r_int = pure_outer_bc_array[idx2d].partial_x0_partial_r_int;
+    const REAL partial_x1_partial_r_int = pure_outer_bc_array[idx2d].partial_x1_partial_r_int;
+    const REAL partial_x2_partial_r_int = pure_outer_bc_array[idx2d].partial_x2_partial_r_int;
     for (int which_gf = 0; which_gf < NUM_EVOL_GFS; which_gf++) {
       // *** Apply radiation BCs to all outer boundary points. ***
-      rhs_gfs[IDX4pt(which_gf, idx3)] = radiation_bcs(params, xx, gfs, rhs_gfs, which_gf, custom_wavespeed[which_gf], custom_f_infinity[which_gf], i0,
-                                                      i1, i2, FACEX0, FACEX1, FACEX2);
+      rhs_gfs[IDX4pt(which_gf, idx3)] =
+          radiation_bcs(params, xx, gfs, rhs_gfs, which_gf, custom_wavespeed[which_gf], custom_f_infinity[which_gf], i0, i1, i2, FACEX0, FACEX1,
+                        FACEX2, r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r, r_int, partial_x0_partial_r_int,
+                        partial_x1_partial_r_int, partial_x2_partial_r_int);
     }
   }
 } // END FUNCTION: apply_bcs_pure_only_host

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__openmp__SinhCylindricalv2n2.c
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__openmp__SinhCylindricalv2n2.c
@@ -76,51 +76,6 @@ static inline REAL FD1_arbitrary_upwind_x2_dirn(const params_struct *restrict pa
   return 0.0 / 0.0; // poison output if offset computed incorrectly
 } // END FUNCTION: FD1_arbitrary_upwind_x2_dirn
 /**
- * Compute r(xx0,xx1,xx2) and partial_r x^i.
- */
-static inline void r_and_partial_xi_partial_r_derivs(const params_struct *restrict params, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
-                                                     REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
-  const REAL AMPLRHO = params->AMPLRHO;
-  const REAL AMPLZ = params->AMPLZ;
-  const REAL SINHWRHO = params->SINHWRHO;
-  const REAL SINHWZ = params->SINHWZ;
-  const REAL rho_slope = params->rho_slope;
-  const REAL z_slope = params->z_slope;
-
-  const REAL tmp0 = (1.0 / (SINHWRHO));
-  const REAL tmp6 = AMPLRHO - rho_slope;
-  const REAL tmp9 = (1.0 / (SINHWZ));
-  const REAL tmp15 = AMPLZ - z_slope;
-  const REAL tmp5 = (1.0 / (exp(tmp0) - exp(-tmp0)));
-  const REAL tmp14 = (1.0 / (exp(tmp9) - exp(-tmp9)));
-  const REAL tmp2 = exp(tmp0 * xx0);
-  const REAL tmp3 = exp(-tmp0 * xx0);
-  const REAL tmp7 = tmp5 * tmp6 * ((xx0) * (xx0));
-  const REAL tmp11 = exp(tmp9 * xx2);
-  const REAL tmp12 = exp(-tmp9 * xx2);
-  const REAL tmp16 = tmp14 * tmp15 * ((xx2) * (xx2));
-  const REAL tmp4 = tmp2 - tmp3;
-  const REAL tmp13 = tmp11 - tmp12;
-  const REAL tmp22 = tmp16 * (tmp11 * tmp9 + tmp12 * tmp9);
-  const REAL tmp8 = rho_slope * xx0 + tmp4 * tmp7;
-  const REAL tmp17 = tmp13 * tmp16 + xx2 * z_slope;
-  const REAL tmp21 = tmp13 * tmp14 * tmp15 * xx2;
-  const REAL tmp18 = ((tmp17) * (tmp17));
-  const REAL tmp25 = tmp8 * (2 * rho_slope + 4 * tmp4 * tmp5 * tmp6 * xx0 + 2 * tmp7 * (tmp0 * tmp2 + tmp0 * tmp3));
-  const REAL tmp19 = tmp18 + ((tmp8) * (tmp8));
-  const REAL tmp23 = tmp18 * (4 * tmp21 + 2 * tmp22 + 2 * z_slope);
-  const REAL tmp20 = sqrt(tmp19);
-  const REAL tmp24 = (1.0 / sqrt(-tmp18 / tmp19 + 1));
-  const REAL tmp28 = (1.0 / 2.0) / pow(tmp19, 3.0 / 2.0);
-  const REAL tmp27 = (1.0 / (tmp20));
-  const REAL tmp29 = tmp24 * (-tmp23 * tmp28 + tmp27 * (2 * tmp21 + tmp22 + z_slope));
-  const REAL tmp30 = (1.0 / ((1.0 / 2.0) * tmp25 * tmp27 * tmp29 + (1.0 / 4.0) * tmp23 * tmp24 * tmp25 / ((tmp19) * (tmp19))));
-  *r = tmp20;
-  *partial_x0_partial_r = tmp29 * tmp30;
-  *partial_x1_partial_r = 0;
-  *partial_x2_partial_r = tmp17 * tmp24 * tmp25 * tmp28 * tmp30;
-} // END FUNCTION: r_and_partial_xi_partial_r_derivs
-/**
  * Compute \partial_r f
  */
 static inline REAL compute_partial_r_f(const params_struct *restrict params, REAL *restrict xx[3], const REAL *restrict gfs, const int which_gf,
@@ -177,7 +132,9 @@ static inline REAL compute_partial_r_f(const params_struct *restrict params, REA
  */
 static inline REAL radiation_bcs(const params_struct *restrict params, REAL *restrict xx[3], const REAL *restrict gfs, REAL *restrict gfs_rhss,
                                  const int which_gf, const REAL gf_wavespeed, const REAL gf_f_infinity, const int dest_i0, const int dest_i1,
-                                 const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2) {
+                                 const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2, const REAL r,
+                                 const REAL partial_x0_partial_r, const REAL partial_x1_partial_r, const REAL partial_x2_partial_r, const REAL r_int,
+                                 const REAL partial_x0_partial_r_int, const REAL partial_x1_partial_r_int, const REAL partial_x2_partial_r_int) {
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
@@ -188,12 +145,6 @@ static inline REAL radiation_bcs(const params_struct *restrict params, REAL *res
 
   // Nearest "interior" neighbor of this gridpoint, based on current face
   const int dest_i0_int = dest_i0 + 1 * FACEi0, dest_i1_int = dest_i1 + 1 * FACEi1, dest_i2_int = dest_i2 + 1 * FACEi2;
-  REAL r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r;
-  REAL r_int, partial_x0_partial_r_int, partial_x1_partial_r_int, partial_x2_partial_r_int;
-  r_and_partial_xi_partial_r_derivs(params, xx[0][dest_i0], xx[1][dest_i1], xx[2][dest_i2], &r, &partial_x0_partial_r, &partial_x1_partial_r,
-                                    &partial_x2_partial_r);
-  r_and_partial_xi_partial_r_derivs(params, xx[0][dest_i0_int], xx[1][dest_i1_int], xx[2][dest_i2_int], &r_int, &partial_x0_partial_r_int,
-                                    &partial_x1_partial_r_int, &partial_x2_partial_r_int);
   const REAL partial_r_f = compute_partial_r_f(params, xx, gfs, which_gf, dest_i0, dest_i1, dest_i2, FACEi0, FACEi1, FACEi2, partial_x0_partial_r,
                                                partial_x1_partial_r, partial_x2_partial_r);
   const REAL partial_r_f_int = compute_partial_r_f(params, xx, gfs, which_gf, dest_i0_int, dest_i1_int, dest_i2_int, FACEi0, FACEi1, FACEi2,
@@ -243,10 +194,20 @@ static void apply_bcs_pure_only_host(const params_struct *restrict params, const
     const short FACEX2 = pure_outer_bc_array[idx2d].FACEX2;
     const int idx3 = IDX3(i0, i1, i2);
     REAL *xx[3] = {x0, x1, x2};
+    const REAL r = pure_outer_bc_array[idx2d].r;
+    const REAL partial_x0_partial_r = pure_outer_bc_array[idx2d].partial_x0_partial_r;
+    const REAL partial_x1_partial_r = pure_outer_bc_array[idx2d].partial_x1_partial_r;
+    const REAL partial_x2_partial_r = pure_outer_bc_array[idx2d].partial_x2_partial_r;
+    const REAL r_int = pure_outer_bc_array[idx2d].r_int;
+    const REAL partial_x0_partial_r_int = pure_outer_bc_array[idx2d].partial_x0_partial_r_int;
+    const REAL partial_x1_partial_r_int = pure_outer_bc_array[idx2d].partial_x1_partial_r_int;
+    const REAL partial_x2_partial_r_int = pure_outer_bc_array[idx2d].partial_x2_partial_r_int;
     for (int which_gf = 0; which_gf < NUM_EVOL_GFS; which_gf++) {
       // *** Apply radiation BCs to all outer boundary points. ***
-      rhs_gfs[IDX4pt(which_gf, idx3)] = radiation_bcs(params, xx, gfs, rhs_gfs, which_gf, custom_wavespeed[which_gf], custom_f_infinity[which_gf], i0,
-                                                      i1, i2, FACEX0, FACEX1, FACEX2);
+      rhs_gfs[IDX4pt(which_gf, idx3)] =
+          radiation_bcs(params, xx, gfs, rhs_gfs, which_gf, custom_wavespeed[which_gf], custom_f_infinity[which_gf], i0, i1, i2, FACEX0, FACEX1,
+                        FACEX2, r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r, r_int, partial_x0_partial_r_int,
+                        partial_x1_partial_r_int, partial_x2_partial_r_int);
     }
   }
 } // END FUNCTION: apply_bcs_pure_only_host

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__openmp__SinhSymTP.c
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/apply_bcs_outerradiation_and_inner_apply_bcs_outerradiation_and_inner__rfm__openmp__SinhSymTP.c
@@ -76,42 +76,6 @@ static inline REAL FD1_arbitrary_upwind_x1_dirn(const params_struct *restrict pa
   return 0.0 / 0.0; // poison output if offset computed incorrectly
 } // END FUNCTION: FD1_arbitrary_upwind_x1_dirn
 /**
- * Compute r(xx0,xx1,xx2) and partial_r x^i.
- */
-static inline void r_and_partial_xi_partial_r_derivs(const params_struct *restrict params, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
-                                                     REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
-  const REAL AMAX = params->AMAX;
-  const REAL SINHWAA = params->SINHWAA;
-  const REAL bScale = params->bScale;
-
-  const REAL tmp0 = sin(xx1);
-  const REAL tmp2 = (1.0 / (SINHWAA));
-  const REAL tmp9 = cos(xx1);
-  const REAL tmp7 = ((AMAX) * (AMAX)) / ((exp(tmp2) - exp(-tmp2)) * (exp(tmp2) - exp(-tmp2)));
-  const REAL tmp4 = exp(tmp2 * xx0);
-  const REAL tmp5 = exp(-tmp2 * xx0);
-  const REAL tmp6 = tmp4 - tmp5;
-  const REAL tmp8 = ((tmp6) * (tmp6)) * tmp7;
-  const REAL tmp23 = (1.0 / 2.0) * tmp6 * tmp7 * (2 * tmp2 * tmp4 + 2 * tmp2 * tmp5);
-  const REAL tmp11 = ((bScale) * (bScale)) + tmp8;
-  const REAL tmp24 = ((tmp0) * (tmp0)) * tmp23 + tmp23 * ((tmp9) * (tmp9));
-  const REAL tmp12 = tmp11 * ((tmp9) * (tmp9));
-  const REAL tmp15 = sqrt(tmp11);
-  const REAL tmp18 = -tmp0 * tmp11 * tmp9 + tmp0 * tmp8 * tmp9;
-  const REAL tmp13 = ((tmp0) * (tmp0)) * tmp8 + tmp12;
-  const REAL tmp14 = sqrt(tmp13);
-  const REAL tmp19 = pow(tmp13, -3.0 / 2.0);
-  const REAL tmp21 = (1.0 / sqrt(-tmp12 / tmp13 + 1));
-  const REAL tmp16 = (1.0 / (tmp14));
-  const REAL tmp20 = -tmp0 * tmp15 * tmp16 - tmp15 * tmp18 * tmp19 * tmp9;
-  const REAL tmp25 = -tmp15 * tmp19 * tmp24 * tmp9 + tmp16 * tmp23 * tmp9 / tmp15;
-  const REAL tmp26 = tmp21 / (tmp16 * tmp18 * tmp21 * tmp25 - tmp16 * tmp20 * tmp21 * tmp24);
-  *r = tmp14;
-  *partial_x0_partial_r = -tmp20 * tmp26;
-  *partial_x1_partial_r = tmp25 * tmp26;
-  *partial_x2_partial_r = 0;
-} // END FUNCTION: r_and_partial_xi_partial_r_derivs
-/**
  * Compute \partial_r f
  */
 static inline REAL compute_partial_r_f(const params_struct *restrict params, REAL *restrict xx[3], const REAL *restrict gfs, const int which_gf,
@@ -168,7 +132,9 @@ static inline REAL compute_partial_r_f(const params_struct *restrict params, REA
  */
 static inline REAL radiation_bcs(const params_struct *restrict params, REAL *restrict xx[3], const REAL *restrict gfs, REAL *restrict gfs_rhss,
                                  const int which_gf, const REAL gf_wavespeed, const REAL gf_f_infinity, const int dest_i0, const int dest_i1,
-                                 const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2) {
+                                 const int dest_i2, const short FACEi0, const short FACEi1, const short FACEi2, const REAL r,
+                                 const REAL partial_x0_partial_r, const REAL partial_x1_partial_r, const REAL partial_x2_partial_r, const REAL r_int,
+                                 const REAL partial_x0_partial_r_int, const REAL partial_x1_partial_r_int, const REAL partial_x2_partial_r_int) {
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS0 = params->Nxx_plus_2NGHOSTS0;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS1 = params->Nxx_plus_2NGHOSTS1;
   MAYBE_UNUSED const int Nxx_plus_2NGHOSTS2 = params->Nxx_plus_2NGHOSTS2;
@@ -179,12 +145,6 @@ static inline REAL radiation_bcs(const params_struct *restrict params, REAL *res
 
   // Nearest "interior" neighbor of this gridpoint, based on current face
   const int dest_i0_int = dest_i0 + 1 * FACEi0, dest_i1_int = dest_i1 + 1 * FACEi1, dest_i2_int = dest_i2 + 1 * FACEi2;
-  REAL r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r;
-  REAL r_int, partial_x0_partial_r_int, partial_x1_partial_r_int, partial_x2_partial_r_int;
-  r_and_partial_xi_partial_r_derivs(params, xx[0][dest_i0], xx[1][dest_i1], xx[2][dest_i2], &r, &partial_x0_partial_r, &partial_x1_partial_r,
-                                    &partial_x2_partial_r);
-  r_and_partial_xi_partial_r_derivs(params, xx[0][dest_i0_int], xx[1][dest_i1_int], xx[2][dest_i2_int], &r_int, &partial_x0_partial_r_int,
-                                    &partial_x1_partial_r_int, &partial_x2_partial_r_int);
   const REAL partial_r_f = compute_partial_r_f(params, xx, gfs, which_gf, dest_i0, dest_i1, dest_i2, FACEi0, FACEi1, FACEi2, partial_x0_partial_r,
                                                partial_x1_partial_r, partial_x2_partial_r);
   const REAL partial_r_f_int = compute_partial_r_f(params, xx, gfs, which_gf, dest_i0_int, dest_i1_int, dest_i2_int, FACEi0, FACEi1, FACEi2,
@@ -234,10 +194,20 @@ static void apply_bcs_pure_only_host(const params_struct *restrict params, const
     const short FACEX2 = pure_outer_bc_array[idx2d].FACEX2;
     const int idx3 = IDX3(i0, i1, i2);
     REAL *xx[3] = {x0, x1, x2};
+    const REAL r = pure_outer_bc_array[idx2d].r;
+    const REAL partial_x0_partial_r = pure_outer_bc_array[idx2d].partial_x0_partial_r;
+    const REAL partial_x1_partial_r = pure_outer_bc_array[idx2d].partial_x1_partial_r;
+    const REAL partial_x2_partial_r = pure_outer_bc_array[idx2d].partial_x2_partial_r;
+    const REAL r_int = pure_outer_bc_array[idx2d].r_int;
+    const REAL partial_x0_partial_r_int = pure_outer_bc_array[idx2d].partial_x0_partial_r_int;
+    const REAL partial_x1_partial_r_int = pure_outer_bc_array[idx2d].partial_x1_partial_r_int;
+    const REAL partial_x2_partial_r_int = pure_outer_bc_array[idx2d].partial_x2_partial_r_int;
     for (int which_gf = 0; which_gf < NUM_EVOL_GFS; which_gf++) {
       // *** Apply radiation BCs to all outer boundary points. ***
-      rhs_gfs[IDX4pt(which_gf, idx3)] = radiation_bcs(params, xx, gfs, rhs_gfs, which_gf, custom_wavespeed[which_gf], custom_f_infinity[which_gf], i0,
-                                                      i1, i2, FACEX0, FACEX1, FACEX2);
+      rhs_gfs[IDX4pt(which_gf, idx3)] =
+          radiation_bcs(params, xx, gfs, rhs_gfs, which_gf, custom_wavespeed[which_gf], custom_f_infinity[which_gf], i0, i1, i2, FACEX0, FACEX1,
+                        FACEX2, r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r, r_int, partial_x0_partial_r_int,
+                        partial_x1_partial_r_int, partial_x2_partial_r_int);
     }
   }
 } // END FUNCTION: apply_bcs_pure_only_host

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__cuda__Cartesian.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__cuda__Cartesian.cu
@@ -251,6 +251,29 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
   } // END for(int whichparity=0;whichparity<10;whichparity++)
 #undef EPS_REL
 } // END FUNCTION: set_parity_for_inner_boundary_single_pt
+/**
+ * Compute r(xx0,xx1,xx2) and partial_r x^i.
+ */
+static inline void r_and_partial_xi_partial_r_derivs(const params_struct *restrict params, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
+                                                     REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
+  const REAL tmp0 = ((xx2) * (xx2));
+  const REAL tmp3 = ((xx0) * (xx0)) + ((xx1) * (xx1));
+  const REAL tmp4 = tmp0 + tmp3;
+  const REAL tmp5 = sqrt(tmp4);
+  const REAL tmp6 = 1 / (tmp3 * sqrt(-tmp0 / tmp4 + 1));
+  const REAL tmp8 = tmp0 / ((tmp4) * (tmp4));
+  const REAL tmp11 = pow(tmp4, -3.0 / 2.0);
+  const REAL tmp7 = tmp6 * ((xx0) * (xx0));
+  const REAL tmp9 = tmp6 * ((xx1) * (xx1));
+  const REAL tmp10 = (1.0 / (tmp5));
+  const REAL tmp12 = -tmp0 * tmp11 + tmp10;
+  const REAL tmp14 = (1.0 / (tmp10 * tmp12 * tmp7 + tmp10 * tmp12 * tmp9 + tmp7 * tmp8 + tmp8 * tmp9));
+  const REAL tmp15 = tmp12 * tmp14 * tmp6;
+  *r = tmp5;
+  *partial_x0_partial_r = tmp15 * xx0;
+  *partial_x1_partial_r = tmp15 * xx1;
+  *partial_x2_partial_r = tmp14 * (tmp11 * tmp7 * xx2 + tmp11 * tmp9 * xx2);
+} // END FUNCTION: r_and_partial_xi_partial_r_derivs
 
 /**
  * At each coordinate point (x0,x1,x2) situated at grid index (i0,i1,i2):
@@ -274,17 +297,14 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
  *     If (i0,i1,i2) *is* the same as (i0_inbounds,i1_inbounds,i2_inbounds),
  *         then we are at an outer boundary point. Take care of outer BCs in Step 2.
  * Step 2: Set up outer boundary structs bcstruct->outer_bc_array[which_gz][face][idx2d]:
- *   Recall that at each inner boundary point we must set outerpt_bc_struct:
- *     typedef struct __outerpt_bc_struct__ {
- *       short i0,i1,i2;  // the outer boundary point grid index (i0,i1,i2), on the 3D grid
- *       int8_t FACEX0,FACEX1,FACEX2;  // 1-byte integers that store
- *       //                               FACEX0,FACEX1,FACEX2 = +1, 0, 0 if on the i0=i0min face,
- *       //                               FACEX0,FACEX1,FACEX2 = -1, 0, 0 if on the i0=i0max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,+1, 0 if on the i1=i2min face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,-1, 0 if on the i1=i1max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,+1 if on the i2=i2min face, or
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,-1 if on the i2=i2max face,
- *     } outerpt_bc_struct;
+ *   Recall that at each outer boundary point, outerpt_bc_struct stores:
+ *     i0,i1,i2: the outer boundary point grid index on the 3D grid
+ *     FACEX0,FACEX1,FACEX2: face signs, e.g. +1,0,0 on the i0=i0min face and -1,0,0 on the i0=i0max face
+ *     r, partial_x{0,1,2}_partial_r: the radius and dx^i/dr at this point, precomputed here because they
+ *       are grid-static; the radiation BC would otherwise recompute them for every gridfunction on every
+ *       RK substep
+ *     r_int, partial_x{0,1,2}_partial_r_int: the same quantities at the nearest interior neighbour,
+ *       (i0,i1,i2)+(FACEX0,FACEX1,FACEX2)
  *   Outer boundary points are filled from the inside out, two faces at a time.
  *     E.g., consider a Cartesian coordinate grid that has 14 points in each direction,
  *     including the ghostzones, with NGHOSTS=2.
@@ -473,6 +493,18 @@ void bcstruct_set_up__rfm__Cartesian(const commondata_struct *restrict commondat
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on lower faces
@@ -496,6 +528,18 @@ void bcstruct_set_up__rfm__Cartesian(const commondata_struct *restrict commondat
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on upper faces

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__cuda__HoleySinhSpherical.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__cuda__HoleySinhSpherical.cu
@@ -274,6 +274,23 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
   } // END for(int whichparity=0;whichparity<10;whichparity++)
 #undef EPS_REL
 } // END FUNCTION: set_parity_for_inner_boundary_single_pt
+/**
+ * Compute r(xx0,xx1,xx2) and partial_r x^i.
+ */
+static inline void r_and_partial_xi_partial_r_derivs(const params_struct *restrict params, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
+                                                     REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
+  const REAL AMPL = params->AMPL;
+  const REAL SINHW = params->SINHW;
+
+  const REAL tmp0 = (1.0 / (SINHW));
+  const REAL tmp1 = exp(tmp0) - exp(-tmp0);
+  const REAL tmp3 = exp(tmp0 * xx0);
+  const REAL tmp4 = exp(-tmp0 * xx0);
+  *r = AMPL * (tmp3 - tmp4) / tmp1;
+  *partial_x0_partial_r = tmp1 / (AMPL * (tmp0 * tmp3 + tmp0 * tmp4));
+  *partial_x1_partial_r = 0;
+  *partial_x2_partial_r = 0;
+} // END FUNCTION: r_and_partial_xi_partial_r_derivs
 
 /**
  * At each coordinate point (x0,x1,x2) situated at grid index (i0,i1,i2):
@@ -297,17 +314,14 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
  *     If (i0,i1,i2) *is* the same as (i0_inbounds,i1_inbounds,i2_inbounds),
  *         then we are at an outer boundary point. Take care of outer BCs in Step 2.
  * Step 2: Set up outer boundary structs bcstruct->outer_bc_array[which_gz][face][idx2d]:
- *   Recall that at each inner boundary point we must set outerpt_bc_struct:
- *     typedef struct __outerpt_bc_struct__ {
- *       short i0,i1,i2;  // the outer boundary point grid index (i0,i1,i2), on the 3D grid
- *       int8_t FACEX0,FACEX1,FACEX2;  // 1-byte integers that store
- *       //                               FACEX0,FACEX1,FACEX2 = +1, 0, 0 if on the i0=i0min face,
- *       //                               FACEX0,FACEX1,FACEX2 = -1, 0, 0 if on the i0=i0max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,+1, 0 if on the i1=i2min face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,-1, 0 if on the i1=i1max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,+1 if on the i2=i2min face, or
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,-1 if on the i2=i2max face,
- *     } outerpt_bc_struct;
+ *   Recall that at each outer boundary point, outerpt_bc_struct stores:
+ *     i0,i1,i2: the outer boundary point grid index on the 3D grid
+ *     FACEX0,FACEX1,FACEX2: face signs, e.g. +1,0,0 on the i0=i0min face and -1,0,0 on the i0=i0max face
+ *     r, partial_x{0,1,2}_partial_r: the radius and dx^i/dr at this point, precomputed here because they
+ *       are grid-static; the radiation BC would otherwise recompute them for every gridfunction on every
+ *       RK substep
+ *     r_int, partial_x{0,1,2}_partial_r_int: the same quantities at the nearest interior neighbour,
+ *       (i0,i1,i2)+(FACEX0,FACEX1,FACEX2)
  *   Outer boundary points are filled from the inside out, two faces at a time.
  *     E.g., consider a Cartesian coordinate grid that has 14 points in each direction,
  *     including the ghostzones, with NGHOSTS=2.
@@ -496,6 +510,18 @@ void bcstruct_set_up__rfm__HoleySinhSpherical(const commondata_struct *restrict 
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on lower faces
@@ -519,6 +545,18 @@ void bcstruct_set_up__rfm__HoleySinhSpherical(const commondata_struct *restrict 
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on upper faces

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__cuda__SinhCylindricalv2n2.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__cuda__SinhCylindricalv2n2.cu
@@ -263,6 +263,51 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
   } // END for(int whichparity=0;whichparity<10;whichparity++)
 #undef EPS_REL
 } // END FUNCTION: set_parity_for_inner_boundary_single_pt
+/**
+ * Compute r(xx0,xx1,xx2) and partial_r x^i.
+ */
+static inline void r_and_partial_xi_partial_r_derivs(const params_struct *restrict params, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
+                                                     REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
+  const REAL AMPLRHO = params->AMPLRHO;
+  const REAL AMPLZ = params->AMPLZ;
+  const REAL SINHWRHO = params->SINHWRHO;
+  const REAL SINHWZ = params->SINHWZ;
+  const REAL rho_slope = params->rho_slope;
+  const REAL z_slope = params->z_slope;
+
+  const REAL tmp0 = (1.0 / (SINHWRHO));
+  const REAL tmp6 = AMPLRHO - rho_slope;
+  const REAL tmp9 = (1.0 / (SINHWZ));
+  const REAL tmp15 = AMPLZ - z_slope;
+  const REAL tmp5 = (1.0 / (exp(tmp0) - exp(-tmp0)));
+  const REAL tmp14 = (1.0 / (exp(tmp9) - exp(-tmp9)));
+  const REAL tmp2 = exp(tmp0 * xx0);
+  const REAL tmp3 = exp(-tmp0 * xx0);
+  const REAL tmp7 = tmp5 * tmp6 * ((xx0) * (xx0));
+  const REAL tmp11 = exp(tmp9 * xx2);
+  const REAL tmp12 = exp(-tmp9 * xx2);
+  const REAL tmp16 = tmp14 * tmp15 * ((xx2) * (xx2));
+  const REAL tmp4 = tmp2 - tmp3;
+  const REAL tmp13 = tmp11 - tmp12;
+  const REAL tmp22 = tmp16 * (tmp11 * tmp9 + tmp12 * tmp9);
+  const REAL tmp8 = rho_slope * xx0 + tmp4 * tmp7;
+  const REAL tmp17 = tmp13 * tmp16 + xx2 * z_slope;
+  const REAL tmp21 = tmp13 * tmp14 * tmp15 * xx2;
+  const REAL tmp18 = ((tmp17) * (tmp17));
+  const REAL tmp25 = tmp8 * (2 * rho_slope + 4 * tmp4 * tmp5 * tmp6 * xx0 + 2 * tmp7 * (tmp0 * tmp2 + tmp0 * tmp3));
+  const REAL tmp19 = tmp18 + ((tmp8) * (tmp8));
+  const REAL tmp23 = tmp18 * (4 * tmp21 + 2 * tmp22 + 2 * z_slope);
+  const REAL tmp20 = sqrt(tmp19);
+  const REAL tmp24 = (1.0 / sqrt(-tmp18 / tmp19 + 1));
+  const REAL tmp28 = (1.0 / 2.0) / pow(tmp19, 3.0 / 2.0);
+  const REAL tmp27 = (1.0 / (tmp20));
+  const REAL tmp29 = tmp24 * (-tmp23 * tmp28 + tmp27 * (2 * tmp21 + tmp22 + z_slope));
+  const REAL tmp30 = (1.0 / ((1.0 / 2.0) * tmp25 * tmp27 * tmp29 + (1.0 / 4.0) * tmp23 * tmp24 * tmp25 / ((tmp19) * (tmp19))));
+  *r = tmp20;
+  *partial_x0_partial_r = tmp29 * tmp30;
+  *partial_x1_partial_r = 0;
+  *partial_x2_partial_r = tmp17 * tmp24 * tmp25 * tmp28 * tmp30;
+} // END FUNCTION: r_and_partial_xi_partial_r_derivs
 
 /**
  * At each coordinate point (x0,x1,x2) situated at grid index (i0,i1,i2):
@@ -286,17 +331,14 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
  *     If (i0,i1,i2) *is* the same as (i0_inbounds,i1_inbounds,i2_inbounds),
  *         then we are at an outer boundary point. Take care of outer BCs in Step 2.
  * Step 2: Set up outer boundary structs bcstruct->outer_bc_array[which_gz][face][idx2d]:
- *   Recall that at each inner boundary point we must set outerpt_bc_struct:
- *     typedef struct __outerpt_bc_struct__ {
- *       short i0,i1,i2;  // the outer boundary point grid index (i0,i1,i2), on the 3D grid
- *       int8_t FACEX0,FACEX1,FACEX2;  // 1-byte integers that store
- *       //                               FACEX0,FACEX1,FACEX2 = +1, 0, 0 if on the i0=i0min face,
- *       //                               FACEX0,FACEX1,FACEX2 = -1, 0, 0 if on the i0=i0max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,+1, 0 if on the i1=i2min face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,-1, 0 if on the i1=i1max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,+1 if on the i2=i2min face, or
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,-1 if on the i2=i2max face,
- *     } outerpt_bc_struct;
+ *   Recall that at each outer boundary point, outerpt_bc_struct stores:
+ *     i0,i1,i2: the outer boundary point grid index on the 3D grid
+ *     FACEX0,FACEX1,FACEX2: face signs, e.g. +1,0,0 on the i0=i0min face and -1,0,0 on the i0=i0max face
+ *     r, partial_x{0,1,2}_partial_r: the radius and dx^i/dr at this point, precomputed here because they
+ *       are grid-static; the radiation BC would otherwise recompute them for every gridfunction on every
+ *       RK substep
+ *     r_int, partial_x{0,1,2}_partial_r_int: the same quantities at the nearest interior neighbour,
+ *       (i0,i1,i2)+(FACEX0,FACEX1,FACEX2)
  *   Outer boundary points are filled from the inside out, two faces at a time.
  *     E.g., consider a Cartesian coordinate grid that has 14 points in each direction,
  *     including the ghostzones, with NGHOSTS=2.
@@ -485,6 +527,18 @@ void bcstruct_set_up__rfm__SinhCylindricalv2n2(const commondata_struct *restrict
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on lower faces
@@ -508,6 +562,18 @@ void bcstruct_set_up__rfm__SinhCylindricalv2n2(const commondata_struct *restrict
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on upper faces

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__cuda__SinhSymTP.cu
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__cuda__SinhSymTP.cu
@@ -381,6 +381,42 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
   } // END for(int whichparity=0;whichparity<10;whichparity++)
 #undef EPS_REL
 } // END FUNCTION: set_parity_for_inner_boundary_single_pt
+/**
+ * Compute r(xx0,xx1,xx2) and partial_r x^i.
+ */
+static inline void r_and_partial_xi_partial_r_derivs(const params_struct *restrict params, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
+                                                     REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
+  const REAL AMAX = params->AMAX;
+  const REAL SINHWAA = params->SINHWAA;
+  const REAL bScale = params->bScale;
+
+  const REAL tmp0 = sin(xx1);
+  const REAL tmp2 = (1.0 / (SINHWAA));
+  const REAL tmp9 = cos(xx1);
+  const REAL tmp7 = ((AMAX) * (AMAX)) / ((exp(tmp2) - exp(-tmp2)) * (exp(tmp2) - exp(-tmp2)));
+  const REAL tmp4 = exp(tmp2 * xx0);
+  const REAL tmp5 = exp(-tmp2 * xx0);
+  const REAL tmp6 = tmp4 - tmp5;
+  const REAL tmp8 = ((tmp6) * (tmp6)) * tmp7;
+  const REAL tmp23 = (1.0 / 2.0) * tmp6 * tmp7 * (2 * tmp2 * tmp4 + 2 * tmp2 * tmp5);
+  const REAL tmp11 = ((bScale) * (bScale)) + tmp8;
+  const REAL tmp24 = ((tmp0) * (tmp0)) * tmp23 + tmp23 * ((tmp9) * (tmp9));
+  const REAL tmp12 = tmp11 * ((tmp9) * (tmp9));
+  const REAL tmp15 = sqrt(tmp11);
+  const REAL tmp18 = -tmp0 * tmp11 * tmp9 + tmp0 * tmp8 * tmp9;
+  const REAL tmp13 = ((tmp0) * (tmp0)) * tmp8 + tmp12;
+  const REAL tmp14 = sqrt(tmp13);
+  const REAL tmp19 = pow(tmp13, -3.0 / 2.0);
+  const REAL tmp21 = (1.0 / sqrt(-tmp12 / tmp13 + 1));
+  const REAL tmp16 = (1.0 / (tmp14));
+  const REAL tmp20 = -tmp0 * tmp15 * tmp16 - tmp15 * tmp18 * tmp19 * tmp9;
+  const REAL tmp25 = -tmp15 * tmp19 * tmp24 * tmp9 + tmp16 * tmp23 * tmp9 / tmp15;
+  const REAL tmp26 = tmp21 / (tmp16 * tmp18 * tmp21 * tmp25 - tmp16 * tmp20 * tmp21 * tmp24);
+  *r = tmp14;
+  *partial_x0_partial_r = -tmp20 * tmp26;
+  *partial_x1_partial_r = tmp25 * tmp26;
+  *partial_x2_partial_r = 0;
+} // END FUNCTION: r_and_partial_xi_partial_r_derivs
 
 /**
  * At each coordinate point (x0,x1,x2) situated at grid index (i0,i1,i2):
@@ -404,17 +440,14 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
  *     If (i0,i1,i2) *is* the same as (i0_inbounds,i1_inbounds,i2_inbounds),
  *         then we are at an outer boundary point. Take care of outer BCs in Step 2.
  * Step 2: Set up outer boundary structs bcstruct->outer_bc_array[which_gz][face][idx2d]:
- *   Recall that at each inner boundary point we must set outerpt_bc_struct:
- *     typedef struct __outerpt_bc_struct__ {
- *       short i0,i1,i2;  // the outer boundary point grid index (i0,i1,i2), on the 3D grid
- *       int8_t FACEX0,FACEX1,FACEX2;  // 1-byte integers that store
- *       //                               FACEX0,FACEX1,FACEX2 = +1, 0, 0 if on the i0=i0min face,
- *       //                               FACEX0,FACEX1,FACEX2 = -1, 0, 0 if on the i0=i0max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,+1, 0 if on the i1=i2min face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,-1, 0 if on the i1=i1max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,+1 if on the i2=i2min face, or
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,-1 if on the i2=i2max face,
- *     } outerpt_bc_struct;
+ *   Recall that at each outer boundary point, outerpt_bc_struct stores:
+ *     i0,i1,i2: the outer boundary point grid index on the 3D grid
+ *     FACEX0,FACEX1,FACEX2: face signs, e.g. +1,0,0 on the i0=i0min face and -1,0,0 on the i0=i0max face
+ *     r, partial_x{0,1,2}_partial_r: the radius and dx^i/dr at this point, precomputed here because they
+ *       are grid-static; the radiation BC would otherwise recompute them for every gridfunction on every
+ *       RK substep
+ *     r_int, partial_x{0,1,2}_partial_r_int: the same quantities at the nearest interior neighbour,
+ *       (i0,i1,i2)+(FACEX0,FACEX1,FACEX2)
  *   Outer boundary points are filled from the inside out, two faces at a time.
  *     E.g., consider a Cartesian coordinate grid that has 14 points in each direction,
  *     including the ghostzones, with NGHOSTS=2.
@@ -603,6 +636,18 @@ void bcstruct_set_up__rfm__SinhSymTP(const commondata_struct *restrict commondat
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on lower faces
@@ -626,6 +671,18 @@ void bcstruct_set_up__rfm__SinhSymTP(const commondata_struct *restrict commondat
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on upper faces

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__openmp__Cartesian.c
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__openmp__Cartesian.c
@@ -251,6 +251,29 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
   } // END for(int whichparity=0;whichparity<10;whichparity++)
 #undef EPS_REL
 } // END FUNCTION: set_parity_for_inner_boundary_single_pt
+/**
+ * Compute r(xx0,xx1,xx2) and partial_r x^i.
+ */
+static inline void r_and_partial_xi_partial_r_derivs(const params_struct *restrict params, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
+                                                     REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
+  const REAL tmp0 = ((xx2) * (xx2));
+  const REAL tmp3 = ((xx0) * (xx0)) + ((xx1) * (xx1));
+  const REAL tmp4 = tmp0 + tmp3;
+  const REAL tmp5 = sqrt(tmp4);
+  const REAL tmp6 = 1 / (tmp3 * sqrt(-tmp0 / tmp4 + 1));
+  const REAL tmp8 = tmp0 / ((tmp4) * (tmp4));
+  const REAL tmp11 = pow(tmp4, -3.0 / 2.0);
+  const REAL tmp7 = tmp6 * ((xx0) * (xx0));
+  const REAL tmp9 = tmp6 * ((xx1) * (xx1));
+  const REAL tmp10 = (1.0 / (tmp5));
+  const REAL tmp12 = -tmp0 * tmp11 + tmp10;
+  const REAL tmp14 = (1.0 / (tmp10 * tmp12 * tmp7 + tmp10 * tmp12 * tmp9 + tmp7 * tmp8 + tmp8 * tmp9));
+  const REAL tmp15 = tmp12 * tmp14 * tmp6;
+  *r = tmp5;
+  *partial_x0_partial_r = tmp15 * xx0;
+  *partial_x1_partial_r = tmp15 * xx1;
+  *partial_x2_partial_r = tmp14 * (tmp11 * tmp7 * xx2 + tmp11 * tmp9 * xx2);
+} // END FUNCTION: r_and_partial_xi_partial_r_derivs
 
 /**
  * At each coordinate point (x0,x1,x2) situated at grid index (i0,i1,i2):
@@ -274,17 +297,14 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
  *     If (i0,i1,i2) *is* the same as (i0_inbounds,i1_inbounds,i2_inbounds),
  *         then we are at an outer boundary point. Take care of outer BCs in Step 2.
  * Step 2: Set up outer boundary structs bcstruct->outer_bc_array[which_gz][face][idx2d]:
- *   Recall that at each inner boundary point we must set outerpt_bc_struct:
- *     typedef struct __outerpt_bc_struct__ {
- *       short i0,i1,i2;  // the outer boundary point grid index (i0,i1,i2), on the 3D grid
- *       int8_t FACEX0,FACEX1,FACEX2;  // 1-byte integers that store
- *       //                               FACEX0,FACEX1,FACEX2 = +1, 0, 0 if on the i0=i0min face,
- *       //                               FACEX0,FACEX1,FACEX2 = -1, 0, 0 if on the i0=i0max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,+1, 0 if on the i1=i2min face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,-1, 0 if on the i1=i1max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,+1 if on the i2=i2min face, or
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,-1 if on the i2=i2max face,
- *     } outerpt_bc_struct;
+ *   Recall that at each outer boundary point, outerpt_bc_struct stores:
+ *     i0,i1,i2: the outer boundary point grid index on the 3D grid
+ *     FACEX0,FACEX1,FACEX2: face signs, e.g. +1,0,0 on the i0=i0min face and -1,0,0 on the i0=i0max face
+ *     r, partial_x{0,1,2}_partial_r: the radius and dx^i/dr at this point, precomputed here because they
+ *       are grid-static; the radiation BC would otherwise recompute them for every gridfunction on every
+ *       RK substep
+ *     r_int, partial_x{0,1,2}_partial_r_int: the same quantities at the nearest interior neighbour,
+ *       (i0,i1,i2)+(FACEX0,FACEX1,FACEX2)
  *   Outer boundary points are filled from the inside out, two faces at a time.
  *     E.g., consider a Cartesian coordinate grid that has 14 points in each direction,
  *     including the ghostzones, with NGHOSTS=2.
@@ -473,6 +493,18 @@ void bcstruct_set_up__rfm__Cartesian(const commondata_struct *restrict commondat
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on lower faces
@@ -496,6 +528,18 @@ void bcstruct_set_up__rfm__Cartesian(const commondata_struct *restrict commondat
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on upper faces

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__openmp__HoleySinhSpherical.c
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__openmp__HoleySinhSpherical.c
@@ -274,6 +274,23 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
   } // END for(int whichparity=0;whichparity<10;whichparity++)
 #undef EPS_REL
 } // END FUNCTION: set_parity_for_inner_boundary_single_pt
+/**
+ * Compute r(xx0,xx1,xx2) and partial_r x^i.
+ */
+static inline void r_and_partial_xi_partial_r_derivs(const params_struct *restrict params, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
+                                                     REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
+  const REAL AMPL = params->AMPL;
+  const REAL SINHW = params->SINHW;
+
+  const REAL tmp0 = (1.0 / (SINHW));
+  const REAL tmp1 = exp(tmp0) - exp(-tmp0);
+  const REAL tmp3 = exp(tmp0 * xx0);
+  const REAL tmp4 = exp(-tmp0 * xx0);
+  *r = AMPL * (tmp3 - tmp4) / tmp1;
+  *partial_x0_partial_r = tmp1 / (AMPL * (tmp0 * tmp3 + tmp0 * tmp4));
+  *partial_x1_partial_r = 0;
+  *partial_x2_partial_r = 0;
+} // END FUNCTION: r_and_partial_xi_partial_r_derivs
 
 /**
  * At each coordinate point (x0,x1,x2) situated at grid index (i0,i1,i2):
@@ -297,17 +314,14 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
  *     If (i0,i1,i2) *is* the same as (i0_inbounds,i1_inbounds,i2_inbounds),
  *         then we are at an outer boundary point. Take care of outer BCs in Step 2.
  * Step 2: Set up outer boundary structs bcstruct->outer_bc_array[which_gz][face][idx2d]:
- *   Recall that at each inner boundary point we must set outerpt_bc_struct:
- *     typedef struct __outerpt_bc_struct__ {
- *       short i0,i1,i2;  // the outer boundary point grid index (i0,i1,i2), on the 3D grid
- *       int8_t FACEX0,FACEX1,FACEX2;  // 1-byte integers that store
- *       //                               FACEX0,FACEX1,FACEX2 = +1, 0, 0 if on the i0=i0min face,
- *       //                               FACEX0,FACEX1,FACEX2 = -1, 0, 0 if on the i0=i0max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,+1, 0 if on the i1=i2min face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,-1, 0 if on the i1=i1max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,+1 if on the i2=i2min face, or
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,-1 if on the i2=i2max face,
- *     } outerpt_bc_struct;
+ *   Recall that at each outer boundary point, outerpt_bc_struct stores:
+ *     i0,i1,i2: the outer boundary point grid index on the 3D grid
+ *     FACEX0,FACEX1,FACEX2: face signs, e.g. +1,0,0 on the i0=i0min face and -1,0,0 on the i0=i0max face
+ *     r, partial_x{0,1,2}_partial_r: the radius and dx^i/dr at this point, precomputed here because they
+ *       are grid-static; the radiation BC would otherwise recompute them for every gridfunction on every
+ *       RK substep
+ *     r_int, partial_x{0,1,2}_partial_r_int: the same quantities at the nearest interior neighbour,
+ *       (i0,i1,i2)+(FACEX0,FACEX1,FACEX2)
  *   Outer boundary points are filled from the inside out, two faces at a time.
  *     E.g., consider a Cartesian coordinate grid that has 14 points in each direction,
  *     including the ghostzones, with NGHOSTS=2.
@@ -496,6 +510,18 @@ void bcstruct_set_up__rfm__HoleySinhSpherical(const commondata_struct *restrict 
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on lower faces
@@ -519,6 +545,18 @@ void bcstruct_set_up__rfm__HoleySinhSpherical(const commondata_struct *restrict 
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on upper faces

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__openmp__SinhCylindricalv2n2.c
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__openmp__SinhCylindricalv2n2.c
@@ -263,6 +263,51 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
   } // END for(int whichparity=0;whichparity<10;whichparity++)
 #undef EPS_REL
 } // END FUNCTION: set_parity_for_inner_boundary_single_pt
+/**
+ * Compute r(xx0,xx1,xx2) and partial_r x^i.
+ */
+static inline void r_and_partial_xi_partial_r_derivs(const params_struct *restrict params, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
+                                                     REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
+  const REAL AMPLRHO = params->AMPLRHO;
+  const REAL AMPLZ = params->AMPLZ;
+  const REAL SINHWRHO = params->SINHWRHO;
+  const REAL SINHWZ = params->SINHWZ;
+  const REAL rho_slope = params->rho_slope;
+  const REAL z_slope = params->z_slope;
+
+  const REAL tmp0 = (1.0 / (SINHWRHO));
+  const REAL tmp6 = AMPLRHO - rho_slope;
+  const REAL tmp9 = (1.0 / (SINHWZ));
+  const REAL tmp15 = AMPLZ - z_slope;
+  const REAL tmp5 = (1.0 / (exp(tmp0) - exp(-tmp0)));
+  const REAL tmp14 = (1.0 / (exp(tmp9) - exp(-tmp9)));
+  const REAL tmp2 = exp(tmp0 * xx0);
+  const REAL tmp3 = exp(-tmp0 * xx0);
+  const REAL tmp7 = tmp5 * tmp6 * ((xx0) * (xx0));
+  const REAL tmp11 = exp(tmp9 * xx2);
+  const REAL tmp12 = exp(-tmp9 * xx2);
+  const REAL tmp16 = tmp14 * tmp15 * ((xx2) * (xx2));
+  const REAL tmp4 = tmp2 - tmp3;
+  const REAL tmp13 = tmp11 - tmp12;
+  const REAL tmp22 = tmp16 * (tmp11 * tmp9 + tmp12 * tmp9);
+  const REAL tmp8 = rho_slope * xx0 + tmp4 * tmp7;
+  const REAL tmp17 = tmp13 * tmp16 + xx2 * z_slope;
+  const REAL tmp21 = tmp13 * tmp14 * tmp15 * xx2;
+  const REAL tmp18 = ((tmp17) * (tmp17));
+  const REAL tmp25 = tmp8 * (2 * rho_slope + 4 * tmp4 * tmp5 * tmp6 * xx0 + 2 * tmp7 * (tmp0 * tmp2 + tmp0 * tmp3));
+  const REAL tmp19 = tmp18 + ((tmp8) * (tmp8));
+  const REAL tmp23 = tmp18 * (4 * tmp21 + 2 * tmp22 + 2 * z_slope);
+  const REAL tmp20 = sqrt(tmp19);
+  const REAL tmp24 = (1.0 / sqrt(-tmp18 / tmp19 + 1));
+  const REAL tmp28 = (1.0 / 2.0) / pow(tmp19, 3.0 / 2.0);
+  const REAL tmp27 = (1.0 / (tmp20));
+  const REAL tmp29 = tmp24 * (-tmp23 * tmp28 + tmp27 * (2 * tmp21 + tmp22 + z_slope));
+  const REAL tmp30 = (1.0 / ((1.0 / 2.0) * tmp25 * tmp27 * tmp29 + (1.0 / 4.0) * tmp23 * tmp24 * tmp25 / ((tmp19) * (tmp19))));
+  *r = tmp20;
+  *partial_x0_partial_r = tmp29 * tmp30;
+  *partial_x1_partial_r = 0;
+  *partial_x2_partial_r = tmp17 * tmp24 * tmp25 * tmp28 * tmp30;
+} // END FUNCTION: r_and_partial_xi_partial_r_derivs
 
 /**
  * At each coordinate point (x0,x1,x2) situated at grid index (i0,i1,i2):
@@ -286,17 +331,14 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
  *     If (i0,i1,i2) *is* the same as (i0_inbounds,i1_inbounds,i2_inbounds),
  *         then we are at an outer boundary point. Take care of outer BCs in Step 2.
  * Step 2: Set up outer boundary structs bcstruct->outer_bc_array[which_gz][face][idx2d]:
- *   Recall that at each inner boundary point we must set outerpt_bc_struct:
- *     typedef struct __outerpt_bc_struct__ {
- *       short i0,i1,i2;  // the outer boundary point grid index (i0,i1,i2), on the 3D grid
- *       int8_t FACEX0,FACEX1,FACEX2;  // 1-byte integers that store
- *       //                               FACEX0,FACEX1,FACEX2 = +1, 0, 0 if on the i0=i0min face,
- *       //                               FACEX0,FACEX1,FACEX2 = -1, 0, 0 if on the i0=i0max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,+1, 0 if on the i1=i2min face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,-1, 0 if on the i1=i1max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,+1 if on the i2=i2min face, or
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,-1 if on the i2=i2max face,
- *     } outerpt_bc_struct;
+ *   Recall that at each outer boundary point, outerpt_bc_struct stores:
+ *     i0,i1,i2: the outer boundary point grid index on the 3D grid
+ *     FACEX0,FACEX1,FACEX2: face signs, e.g. +1,0,0 on the i0=i0min face and -1,0,0 on the i0=i0max face
+ *     r, partial_x{0,1,2}_partial_r: the radius and dx^i/dr at this point, precomputed here because they
+ *       are grid-static; the radiation BC would otherwise recompute them for every gridfunction on every
+ *       RK substep
+ *     r_int, partial_x{0,1,2}_partial_r_int: the same quantities at the nearest interior neighbour,
+ *       (i0,i1,i2)+(FACEX0,FACEX1,FACEX2)
  *   Outer boundary points are filled from the inside out, two faces at a time.
  *     E.g., consider a Cartesian coordinate grid that has 14 points in each direction,
  *     including the ghostzones, with NGHOSTS=2.
@@ -485,6 +527,18 @@ void bcstruct_set_up__rfm__SinhCylindricalv2n2(const commondata_struct *restrict
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on lower faces
@@ -508,6 +562,18 @@ void bcstruct_set_up__rfm__SinhCylindricalv2n2(const commondata_struct *restrict
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on upper faces

--- a/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__openmp__SinhSymTP.c
+++ b/nrpy/infrastructures/BHaH/CurviBoundaryConditions/tests/bcstruct_set_up_bcstruct_set_up__rfm__openmp__SinhSymTP.c
@@ -381,6 +381,42 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
   } // END for(int whichparity=0;whichparity<10;whichparity++)
 #undef EPS_REL
 } // END FUNCTION: set_parity_for_inner_boundary_single_pt
+/**
+ * Compute r(xx0,xx1,xx2) and partial_r x^i.
+ */
+static inline void r_and_partial_xi_partial_r_derivs(const params_struct *restrict params, const REAL xx0, const REAL xx1, const REAL xx2, REAL *r,
+                                                     REAL *partial_x0_partial_r, REAL *partial_x1_partial_r, REAL *partial_x2_partial_r) {
+  const REAL AMAX = params->AMAX;
+  const REAL SINHWAA = params->SINHWAA;
+  const REAL bScale = params->bScale;
+
+  const REAL tmp0 = sin(xx1);
+  const REAL tmp2 = (1.0 / (SINHWAA));
+  const REAL tmp9 = cos(xx1);
+  const REAL tmp7 = ((AMAX) * (AMAX)) / ((exp(tmp2) - exp(-tmp2)) * (exp(tmp2) - exp(-tmp2)));
+  const REAL tmp4 = exp(tmp2 * xx0);
+  const REAL tmp5 = exp(-tmp2 * xx0);
+  const REAL tmp6 = tmp4 - tmp5;
+  const REAL tmp8 = ((tmp6) * (tmp6)) * tmp7;
+  const REAL tmp23 = (1.0 / 2.0) * tmp6 * tmp7 * (2 * tmp2 * tmp4 + 2 * tmp2 * tmp5);
+  const REAL tmp11 = ((bScale) * (bScale)) + tmp8;
+  const REAL tmp24 = ((tmp0) * (tmp0)) * tmp23 + tmp23 * ((tmp9) * (tmp9));
+  const REAL tmp12 = tmp11 * ((tmp9) * (tmp9));
+  const REAL tmp15 = sqrt(tmp11);
+  const REAL tmp18 = -tmp0 * tmp11 * tmp9 + tmp0 * tmp8 * tmp9;
+  const REAL tmp13 = ((tmp0) * (tmp0)) * tmp8 + tmp12;
+  const REAL tmp14 = sqrt(tmp13);
+  const REAL tmp19 = pow(tmp13, -3.0 / 2.0);
+  const REAL tmp21 = (1.0 / sqrt(-tmp12 / tmp13 + 1));
+  const REAL tmp16 = (1.0 / (tmp14));
+  const REAL tmp20 = -tmp0 * tmp15 * tmp16 - tmp15 * tmp18 * tmp19 * tmp9;
+  const REAL tmp25 = -tmp15 * tmp19 * tmp24 * tmp9 + tmp16 * tmp23 * tmp9 / tmp15;
+  const REAL tmp26 = tmp21 / (tmp16 * tmp18 * tmp21 * tmp25 - tmp16 * tmp20 * tmp21 * tmp24);
+  *r = tmp14;
+  *partial_x0_partial_r = -tmp20 * tmp26;
+  *partial_x1_partial_r = tmp25 * tmp26;
+  *partial_x2_partial_r = 0;
+} // END FUNCTION: r_and_partial_xi_partial_r_derivs
 
 /**
  * At each coordinate point (x0,x1,x2) situated at grid index (i0,i1,i2):
@@ -404,17 +440,14 @@ static void set_parity_for_inner_boundary_single_pt(const commondata_struct *res
  *     If (i0,i1,i2) *is* the same as (i0_inbounds,i1_inbounds,i2_inbounds),
  *         then we are at an outer boundary point. Take care of outer BCs in Step 2.
  * Step 2: Set up outer boundary structs bcstruct->outer_bc_array[which_gz][face][idx2d]:
- *   Recall that at each inner boundary point we must set outerpt_bc_struct:
- *     typedef struct __outerpt_bc_struct__ {
- *       short i0,i1,i2;  // the outer boundary point grid index (i0,i1,i2), on the 3D grid
- *       int8_t FACEX0,FACEX1,FACEX2;  // 1-byte integers that store
- *       //                               FACEX0,FACEX1,FACEX2 = +1, 0, 0 if on the i0=i0min face,
- *       //                               FACEX0,FACEX1,FACEX2 = -1, 0, 0 if on the i0=i0max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,+1, 0 if on the i1=i2min face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0,-1, 0 if on the i1=i1max face,
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,+1 if on the i2=i2min face, or
- *       //                               FACEX0,FACEX1,FACEX2 =  0, 0,-1 if on the i2=i2max face,
- *     } outerpt_bc_struct;
+ *   Recall that at each outer boundary point, outerpt_bc_struct stores:
+ *     i0,i1,i2: the outer boundary point grid index on the 3D grid
+ *     FACEX0,FACEX1,FACEX2: face signs, e.g. +1,0,0 on the i0=i0min face and -1,0,0 on the i0=i0max face
+ *     r, partial_x{0,1,2}_partial_r: the radius and dx^i/dr at this point, precomputed here because they
+ *       are grid-static; the radiation BC would otherwise recompute them for every gridfunction on every
+ *       RK substep
+ *     r_int, partial_x{0,1,2}_partial_r_int: the same quantities at the nearest interior neighbour,
+ *       (i0,i1,i2)+(FACEX0,FACEX1,FACEX2)
  *   Outer boundary points are filled from the inside out, two faces at a time.
  *     E.g., consider a Cartesian coordinate grid that has 14 points in each direction,
  *     including the ghostzones, with NGHOSTS=2.
@@ -603,6 +636,18 @@ void bcstruct_set_up__rfm__SinhSymTP(const commondata_struct *restrict commondat
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on lower faces
@@ -626,6 +671,18 @@ void bcstruct_set_up__rfm__SinhSymTP(const commondata_struct *restrict commondat
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0 = FACEX0;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1 = FACEX1;
             bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2 = FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0], xx[1][i1], xx[2][i2], &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r);
+            const int i0_int = i0 + FACEX0;
+            const int i1_int = i1 + FACEX1;
+            const int i2_int = i2 + FACEX2;
+            r_and_partial_xi_partial_r_derivs(params, xx[0][i0_int], xx[1][i1_int], xx[2][i2_int],
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x0_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x1_partial_r_int,
+                                              &bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].partial_x2_partial_r_int);
             idx2d++;
           } // END IF outer boundary point
         } // END LOOP over all boundary points on upper faces

--- a/nrpy/infrastructures/superB/CurviBoundaryConditions.py
+++ b/nrpy/infrastructures/superB/CurviBoundaryConditions.py
@@ -311,15 +311,11 @@ def register_CFunction_bcstruct_chare_set_up(CoordSystem: str) -> None:
           const int64_t globalidx3 = IDX3GENERAL_64(i0, i1, i2, Nxx_plus_2NGHOSTS0, Nxx_plus_2NGHOSTS1);
           if (globalidx3pt_to_chareidx3(globalidx3, Nxx_plus_2NGHOSTS0, Nxx_plus_2NGHOSTS1, Nxx0chare, Nxx1chare, Nxx2chare, Nchare0, Nchare1,
                                               Nchare2) == idx3_this_chare) {
+            // Copy face signs and precomputed geometry, then remap only the grid indices.
+            bcstruct_chare->pure_outer_bc_array[dirn + (3 * which_gz)][which_idx2d_chare] = bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d];
             bcstruct_chare->pure_outer_bc_array[dirn + (3 * which_gz)][which_idx2d_chare].i0 = MAP_GLOBAL_TO_LOCAL_IDX0(chare_index[0], i0, Nxx0chare);
             bcstruct_chare->pure_outer_bc_array[dirn + (3 * which_gz)][which_idx2d_chare].i1 = MAP_GLOBAL_TO_LOCAL_IDX1(chare_index[1], i1, Nxx1chare);
             bcstruct_chare->pure_outer_bc_array[dirn + (3 * which_gz)][which_idx2d_chare].i2 = MAP_GLOBAL_TO_LOCAL_IDX2(chare_index[2], i2, Nxx2chare);
-            const short FACEX0 = bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX0;
-            const short FACEX1 = bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX1;
-            const short FACEX2 = bcstruct->pure_outer_bc_array[dirn + (3 * which_gz)][idx2d].FACEX2;
-            bcstruct_chare->pure_outer_bc_array[dirn + (3 * which_gz)][which_idx2d_chare].FACEX0 = FACEX0;
-            bcstruct_chare->pure_outer_bc_array[dirn + (3 * which_gz)][which_idx2d_chare].FACEX1 = FACEX1;
-            bcstruct_chare->pure_outer_bc_array[dirn + (3 * which_gz)][which_idx2d_chare].FACEX2 = FACEX2;
             which_idx2d_chare++;
           }
         }
@@ -406,6 +402,8 @@ typedef struct __outerpt_bc_struct__ {
   //                               FACEX0,FACEX1,FACEX2 =  0,-1, 0 if on the i1=i1max face,
   //                               FACEX0,FACEX1,FACEX2 =  0, 0,+1 if on the i2=i2min face, or
   //                               FACEX0,FACEX1,FACEX2 =  0, 0,-1 if on the i2=i2max face,
+  REAL r, partial_x0_partial_r, partial_x1_partial_r, partial_x2_partial_r;  // Geometry at the outer boundary point.
+  REAL r_int, partial_x0_partial_r_int, partial_x1_partial_r_int, partial_x2_partial_r_int;  // Geometry at its nearest interior neighbour.
 } outerpt_bc_struct;
 
 typedef struct __bc_info_struct__ {

--- a/nrpy/infrastructures/superB/superB/superB_pup.py
+++ b/nrpy/infrastructures/superB/superB/superB_pup.py
@@ -306,7 +306,15 @@ void pup_outerpt_bc_struct(PUP::er &p, outerpt_bc_struct &obc) {
   p | obc.FACEX0;
   p | obc.FACEX1;
   p | obc.FACEX2;
-}
+  p | obc.r;
+  p | obc.partial_x0_partial_r;
+  p | obc.partial_x1_partial_r;
+  p | obc.partial_x2_partial_r;
+  p | obc.r_int;
+  p | obc.partial_x0_partial_r_int;
+  p | obc.partial_x1_partial_r_int;
+  p | obc.partial_x2_partial_r_int;
+} // END FUNCTION: pup_outerpt_bc_struct
 
 // PUP routine for struct bc_info_struct
 void pup_bc_info_struct(PUP::er &p, bc_info_struct &bci) {

--- a/nrpy/infrastructures/superB/superB/superB_pup_function_prototypes.h
+++ b/nrpy/infrastructures/superB/superB/superB_pup_function_prototypes.h
@@ -1,6 +1,12 @@
 void pup_commondata_struct(PUP::er &p, commondata_struct &cd);
 void pup_params_struct(PUP::er &p, params_struct &ps);
 void pup_innerpt_bc_struct(PUP::er &p, innerpt_bc_struct &ibc);
+/**
+ * Serialize outer boundary indices, face signs, and cached geometry at the boundary and interior points.
+ *
+ * @param[in,out] p PUP archive used for sizing, packing, or unpacking.
+ * @param[in,out] obc Outer boundary record containing indices, face signs, and both cached geometry samples.
+ */
 void pup_outerpt_bc_struct(PUP::er &p, outerpt_bc_struct &obc);
 void pup_bc_info_struct(PUP::er &p, bc_info_struct &bci);
 void pup_bc_struct(PUP::er &p, bc_struct &bc);


### PR DESCRIPTION
The radiation boundary condition needs r and dx^i/dr at each outer boundary point and at its nearest interior neighbour. These depend only on the grid, but radiation_bcs() recomputed both -- via exp/sinh for sinh-type coordinate maps -- once per gridfunction, per boundary point, per Runge-Kutta substep.

Compute them once in bcstruct_set_up() and store them in outerpt_bc_struct, which grows by eight REALs; radiation_bcs() now takes them as arguments. On the blackhole_spectroscopy benchmark (SinhCylindrical, 64x64x128, 8th order, 194 RK4 steps, 8 pinned cores) this cuts runtime from 117.5 s to 94.1 s, with the libm exponential cost falling from roughly 19% of the profile to under 0.2%.

Results are bit-for-bit unchanged: the same generated expression is evaluated on the same coordinates, only earlier. Verified by building this commit and its parent, running both single-threaded for five steps from identical initial data with diagnostics every step, and comparing: all 17 diagnostic output files and the whole checkpoint gridfunction payload are byte-identical.

setup_Cfunction_r_and_partial_xi_partial_r_derivs() moves from the boundary translation unit to bcstruct_set_up()'s prefunc. Its only caller is host code, so it now unconditionally emits a params_struct signature and drops its CUDA branch and cfunc_decorators parameter, matching the sibling prefunc generators in bcstruct_set_up.py.

Trusted outputs under CurviBoundaryConditions/tests/ are regenerated because the geometry helper moved between translation units and radiation_bcs() gained parameters.

Note for follow-up: nrpy/infrastructures/superB/ declares its own outerpt_bc_struct under the same BHaH_defines key, and its pup_outerpt_bc_struct() and bcstruct_chare_set_up() enumerate members individually. Those three sites need the new members before superB examples using radiation BCs will build and run correctly.


Claude-Session: https://claude.ai/code/session_011sJ6wQbmTEmbapJfvmGbbH